### PR TITLE
Avoid updating dynamic data property values

### DIFF
--- a/src/propertyFields/propertyEditor/PropertyPanePropertyEditorHost.tsx
+++ b/src/propertyFields/propertyEditor/PropertyPanePropertyEditorHost.tsx
@@ -42,9 +42,12 @@ export default class PropertyPanePropertyEditorHost extends React.Component<IPro
     private onSave = (): void => {
         const newProperties = JSON.parse(this.state.propertiesJson);
         for (let propName in newProperties) {
-            set(this.props.webpart.properties, propName, newProperties[propName]);
-            if (typeof this.props.webpart.properties[propName].onChange !== 'undefined' && this.props.webpart.properties[propName].onChange !== null) {
-                this.props.webpart.properties[propName].onChange(propName, newProperties[propName]);
+            // Do not update dynamic data properties
+            if(!(this.props.webpart.properties[propName] && this.props.webpart.properties[propName].__type === "DynamicProperty")) {
+                set(this.props.webpart.properties, propName, newProperties[propName]);
+                if (typeof this.props.webpart.properties[propName].onChange !== 'undefined' && this.props.webpart.properties[propName].onChange !== null) {
+                    this.props.webpart.properties[propName].onChange(propName, newProperties[propName]);
+                }
             }
         }
         this.props.webpart.render();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | Fixes #200 

#### What's in this Pull Request?

Manually updating dyndata property values permanently breaks instances of web parts as described in #200. This avoids saving changes to dynamic data properties from the editor. 

I do not believe they should be filtered out of the editor altogether as it can be quite useful to see a JSON representation of their values.