### PR TITLE
Added Format Code functionality to PropertyFieldCodeEditor property control

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@pnp/sp-clientsvc": "^1.2.8",
     "@pnp/sp-taxonomy": "^1.2.8",
     "@pnp/telemetry-js": "2.0.0",
+    "beautify": "0.0.8",
     "lodash.omit": "^4.5.0",
     "office-ui-fabric-react": "5.131.0",
     "react-ace": "5.8.0"

--- a/src/loc/en-us.js
+++ b/src/loc/en-us.js
@@ -3,6 +3,7 @@ define([], function () {
     ApplyButtonLabel: "Apply",
     ImportButtonLabel: "Import",
     ExportButtonLabel: "Export",
+    FormatCodeButtonLabel: "Format Code",
     JsonFileRequiredMessage: "Please upload a json file",
     SaveButtonLabel: "Save",
     CancelButtonLabel: "Cancel",

--- a/src/loc/fr-fr.js
+++ b/src/loc/fr-fr.js
@@ -3,6 +3,7 @@ define([], function() {
     ApplyButtonLabel: "Apply",
     ImportButtonLabel: "Import",
     ExportButtonLabel: "Export",
+    FormatCodeButtonLabel: "Format Code",
     JsonFileRequiredMessage: "Please upload a json file",
     SaveButtonLabel: "Sauvegarder",
     CancelButtonLabel: "Annuler",

--- a/src/loc/mystrings.d.ts
+++ b/src/loc/mystrings.d.ts
@@ -92,6 +92,7 @@ declare interface IPropertyControlStrings {
   ApplyButtonLabel: string;
   ImportButtonLabel: string;
   ExportButtonLabel: string;
+  FormatCodeButtonLabel: string
   JsonFileRequiredMessage: string;
 
   // Site Picker labels

--- a/src/loc/mystrings.d.ts
+++ b/src/loc/mystrings.d.ts
@@ -92,7 +92,7 @@ declare interface IPropertyControlStrings {
   ApplyButtonLabel: string;
   ImportButtonLabel: string;
   ExportButtonLabel: string;
-  FormatCodeButtonLabel: string
+  FormatCodeButtonLabel: string;
   JsonFileRequiredMessage: string;
 
   // Site Picker labels

--- a/src/loc/nl-nl.js
+++ b/src/loc/nl-nl.js
@@ -3,6 +3,7 @@ define([], function() {
     ApplyButtonLabel: "Bevestig",
     ImportButtonLabel: "Importeer",
     ExportButtonLabel: "Exporteer",
+    FormatCodeButtonLabel: "Format Code",
     JsonFileRequiredMessage: "Alleen JSON files toegestaan",
     SaveButtonLabel: "Opslaan",
     CancelButtonLabel: "Annuleren",

--- a/src/loc/no.js
+++ b/src/loc/no.js
@@ -3,6 +3,7 @@ define([], function() {
     ApplyButtonLabel: "Anvende",
     ImportButtonLabel: "Importere",
     ExportButtonLabel: "Eksportere",
+    FormatCodeButtonLabel: "Format Code",
     JsonFileRequiredMessage: "Vennligst last opp en json fil",
     SaveButtonLabel: "Lagre",
     CancelButtonLabel: "Avbryt",

--- a/src/loc/ru-ru.js
+++ b/src/loc/ru-ru.js
@@ -3,6 +3,7 @@ define([], function() {
       ApplyButtonLabel: "Применить",
       ImportButtonLabel: "Импорт",
       ExportButtonLabel: "Экспорт",
+      FormatCodeButtonLabel: "Format Code",
       JsonFileRequiredMessage: "Пожалуйста, добавьте файл json",
       SaveButtonLabel: "Сохранить",
       CancelButtonLabel: "Отмена",

--- a/src/loc/zh-cn.js
+++ b/src/loc/zh-cn.js
@@ -3,6 +3,7 @@ define([], function () {
     ApplyButtonLabel: "应用",
     ImportButtonLabel: "导入",
     ExportButtonLabel: "导出",
+    FormatCodeButtonLabel: "Format Code",
     JsonFileRequiredMessage: "请上传Json文件",
     SaveButtonLabel: "保存",
     CancelButtonLabel: "取消",

--- a/src/propertyFields/codeEditor/PropertyFieldCodeEditorHost.tsx
+++ b/src/propertyFields/codeEditor/PropertyFieldCodeEditorHost.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Async } from 'office-ui-fabric-react/lib/Utilities';
 import { PrimaryButton, DefaultButton, IButtonProps, IconButton } from 'office-ui-fabric-react/lib/Button';
 import { Panel, PanelType } from 'office-ui-fabric-react/lib/Panel';
-import { IPropertyFieldCodeEditorPropsInternal } from './IPropertyFieldCodeEditor';
+import { IPropertyFieldCodeEditorPropsInternal, PropertyFieldCodeEditorLanguages } from './IPropertyFieldCodeEditor';
 import { Label } from 'office-ui-fabric-react/lib/Label';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { IPropertyFieldCodeEditorHostProps, IPropertyFieldCodeEditorHostState } from './IPropertyFieldCodeEditorHost';
@@ -11,7 +11,6 @@ import FieldErrorMessage from '../errorMessage/FieldErrorMessage';
 import * as telemetry from '../../common/telemetry';
 import * as strings from 'PropertyControlStrings';
 import * as brace from 'brace';
-import * as beautify from 'beautify';
 import AceEditor from 'react-ace';
 import 'brace/mode/json';
 import 'brace/mode/javascript';
@@ -21,7 +20,6 @@ import 'brace/mode/html';
 import 'brace/mode/handlebars';
 import 'brace/mode/xml';
 import 'brace/theme/monokai';
-import { PropertyFieldCodeEditorLanguages } from '../../../lib/PropertyFieldCodeEditor';
 
 /**
  * Renders the controls for PropertyFieldCodeEditor component
@@ -141,7 +139,7 @@ export default class PropertyFieldCodeEditorHost extends React.Component<IProper
     }
 
     const beautify = require('beautify');
-    var formattedCode: any = beautify(this.state.code.trim(), { format: codeLanguage });
+    let formattedCode: any = beautify(this.state.code.trim(), { format: codeLanguage });
 
     this.setState({ code: formattedCode });
   }

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
@@ -731,6 +731,24 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                 })
               ]
             },
+            {
+              groupName: "Code Editor",
+              groupFields: [
+                PropertyFieldCodeEditor(
+                  'targetProperty',
+                   {
+                    label: 'Edit HTML Code',
+                    panelTitle: 'Edit HTML Code',
+                    initialValue: this.properties.htmlCode,
+                    onPropertyChange: this.onPropertyPaneFieldChanged,
+                    properties: this.properties,
+                    disabled: false,
+                    key: 'codeEditorFieldId',
+                    language: PropertyFieldCodeEditorLanguages.HTML
+                  }
+                )
+              ]
+            }
           ]
         }
       ]


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| Related issues?  | fixes https://github.com/pnp/sp-dev-fx-property-controls/issues/165

#### What's in this Pull Request?
Added Format Code functionality to PropertyFieldCodeEditor property control for languages including JSON, JavaScript, Sass, TypeScript", HTML, Handlebars, XML, css.
When the language is Plain Text, the "Format Code" button is hidden.