### PR TITLE
Feature/fix - Escape single quote in folder name + add support for special chars in folder names

### DIFF
--- a/src/services/FolderExplorerService.ts
+++ b/src/services/FolderExplorerService.ts
@@ -67,7 +67,8 @@ export class FolderExplorerService implements IFolderExplorerService {
     let results: IFolder[] = [];
     try {
       const web = new Web(webAbsoluteUrl);
-      let foldersResult: IFolder[] = await web.getFolderByServerRelativeUrl(folderRelativeUrl).folders.select('Name', 'ServerRelativeUrl').orderBy('Name').get();
+      folderRelativeUrl = folderRelativeUrl.replace(/\'/ig, "''");
+      let foldersResult: IFolder[] = await web.getFolderByServerRelativePath(encodeURIComponent(folderRelativeUrl)).folders.select('Name', 'ServerRelativeUrl').orderBy('Name').get();
       results = foldersResult.filter(f => f.Name !== "Forms");
     } catch (error) {
       console.error('Error loading folders', error);
@@ -95,7 +96,8 @@ export class FolderExplorerService implements IFolderExplorerService {
     let folder: IFolder = null;
     try {
       const web = new Web(webAbsoluteUrl);
-      let folderAddResult: FolderAddResult = await web.getFolderByServerRelativeUrl(folderRelativeUrl).folders.add(name);
+      folderRelativeUrl = folderRelativeUrl.replace(/\'/ig, "''");
+      let folderAddResult: FolderAddResult = await web.getFolderByServerRelativePath(encodeURIComponent(folderRelativeUrl)).folders.addUsingPath(encodeURIComponent(name));
       if (folderAddResult && folderAddResult.data) {
         folder = {
           Name: folderAddResult.data.Name,

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
@@ -923,8 +923,8 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                   canCreateFolders: true,
                   onSelect: ((folder: IFolder) => { console.log(folder); this.properties.folderPicker = folder; }),
                   rootFolder: {
-                    Name: "Documents",
-                    ServerRelativeUrl: "/sites/gautamdev/Shared Documents"
+                    Name: "GOBCPPT",
+                    ServerRelativeUrl: "/GOBCPPT"
                   },
                 }),
               ]

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
@@ -923,8 +923,8 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                   canCreateFolders: true,
                   onSelect: ((folder: IFolder) => { console.log(folder); this.properties.folderPicker = folder; }),
                   rootFolder: {
-                    Name: "GOBCPPT",
-                    ServerRelativeUrl: "/GOBCPPT"
+                    Name: "Documents",
+                    ServerRelativeUrl: "/Shared Documents"
                   },
                 }),
               ]


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [x]
| New sample?      | [ ]
| Related issues?  | NA

#### What's in this Pull Request?

This PR fixes an issue with retrieving folder names containing single quotes as well as special chars like `#` and `%`.

This PR also add support to create folder names with special chars like `#` and `%` as we are using the new APIs like `getFolderByServerRelativePath` and `addUsingPath`