### PR TITLE
Feature: added stock images support to file picker

### DIFF
--- a/docs/documentation/docs/controls/PropertyFieldFilePicker.md
+++ b/docs/documentation/docs/controls/PropertyFieldFilePicker.md
@@ -86,6 +86,7 @@ The `PropertyFieldFilePicker` control can be configured with the following prope
 | itemsCountQueryLimit | number | no | Number of items to obtain when executing REST queries. Default 100. |
 | hideRecentTab | boolean | no | Specifies if RecentTab should be hidden. |
 | hideWebSearchTab | boolean | no | Specifies if WebSearchTab should be hidden. |
+| hideStockImages | boolean | no | Specifies if StockImagesTab should be hidden. |
 | hideOrganisationalAssetTab | boolean | no | Specifies if OrganisationalAssetTab should be hidden. |
 | hideOneDriveTab | boolean | no | Specifies if OneDriveTab should be hidden. |
 | hideSiteFilesTab | boolean | no | Specifies if SiteFilesTab should be hidden. |

--- a/src/loc/en-us.js
+++ b/src/loc/en-us.js
@@ -191,6 +191,8 @@ define([], function () {
     UploadLinkLabel: "Upload",
     WebSearchLinkLabel: "Web search",
     Yes: "Yes",
+    StockImagesLinkLabel: "Stock images",
+    StockImagesHeader: "Stock Images",
 
     DateTime: {
       "L_RelativeDateTime_AFewSecondsFuture": "In a few seconds",

--- a/src/loc/mystrings.d.ts
+++ b/src/loc/mystrings.d.ts
@@ -202,6 +202,8 @@ declare interface IPropertyControlStrings {
   UploadImageHeader: string;
   UploadLinkLabel: string;
   WebSearchLinkLabel: string;
+  StockImagesLinkLabel: string;
+  StockImagesHeader: string;
   Yes: string;
   DateTime: IDateTimeStrings;
 

--- a/src/propertyFields/filePicker/IPropertyFieldFilePicker.ts
+++ b/src/propertyFields/filePicker/IPropertyFieldFilePicker.ts
@@ -130,7 +130,11 @@ export interface IPropertyFieldFilePickerProps {
   /**
    * The data associated with the selected file
    */
-  filePickerResult: IFilePickerResult;  
+  filePickerResult: IFilePickerResult;
+  /**
+   * Specifies if StockImagesTab should be hidden.
+   */
+  hideStockImages?: boolean;  
 }
 
 export interface IPropertyFieldFilePickerPropsInternal extends IPropertyFieldFilePickerProps {

--- a/src/propertyFields/filePicker/PropertyFieldFilePicker.ts
+++ b/src/propertyFields/filePicker/PropertyFieldFilePicker.ts
@@ -32,6 +32,7 @@ class PropertyFieldFilePickerBuilder implements IPropertyPaneField<IPropertyFiel
   private hideLinkUploadTab: boolean;
   private hideOrganisationalAssetTab: boolean;
   private hideOneDriveTab: boolean;
+  private hideStockImages: boolean;
   
   private customProperties: any;
   private key: string;
@@ -84,6 +85,7 @@ class PropertyFieldFilePickerBuilder implements IPropertyPaneField<IPropertyFiel
     this.hideOrganisationalAssetTab = _properties.hideOrganisationalAssetTab !== undefined ? _properties.hideOrganisationalAssetTab : false;
     this.hideOneDriveTab = _properties.hideOneDriveTab !== undefined ? _properties.hideOneDriveTab : false;
     this.storeLastActiveTab = _properties.storeLastActiveTab !== undefined ? _properties.storeLastActiveTab : true;
+    this.hideStockImages = _properties.hideStockImages !== undefined ? _properties.hideStockImages : false;
     this.onPropertyChange = _properties.onPropertyChange;
     this.customProperties = _properties.properties;
     this.key = _properties.key;
@@ -123,7 +125,7 @@ class PropertyFieldFilePickerBuilder implements IPropertyPaneField<IPropertyFiel
       hideOrganisationalAssetTab: this.hideOrganisationalAssetTab,
       hideOneDriveTab: this.hideOneDriveTab,
       storeLastActiveTab: this.storeLastActiveTab,
-
+      hideStockImages: this.hideStockImages,
       targetProperty: this.targetProperty,
 
       properties: this.customProperties,

--- a/src/propertyFields/filePicker/PropertyFieldFilePickerHost.tsx
+++ b/src/propertyFields/filePicker/PropertyFieldFilePickerHost.tsx
@@ -53,6 +53,7 @@ export default class PropertyFieldFilePickerHost extends React.Component<IProper
           hideLinkUploadTab={this.props.hideLinkUploadTab !== undefined ? this.props.hideLinkUploadTab : false}
           hideOneDriveTab={this.props.hideOneDriveTab !== undefined ? this.props.hideOneDriveTab : false}
           hideOrganisationalAssetTab={this.props.hideOrganisationalAssetTab !== undefined ? this.props.hideOrganisationalAssetTab : false}
+          hideStockImages={this.props.hideStockImages !== undefined ? this.props.hideStockImages : false}
           panelClassName={this.props.panelClassName}
           storeLastActiveTab={this.props.storeLastActiveTab}
         />

--- a/src/propertyFields/filePicker/filePickerControls/FilePicker.tsx
+++ b/src/propertyFields/filePicker/filePickerControls/FilePicker.tsx
@@ -24,6 +24,7 @@ import { OneDriveService } from '../../../services/OneDriveService';
 import { OrgAssetsService } from '../../../services/OrgAssetsService';
 import { IFilePickerResult } from './FilePicker.types';
 import { FilesSearchService } from '../../../services/FilesSearchService';
+import { StockImages } from './StockImagesTab';
 
 export class FilePicker extends React.Component<IFilePickerProps, IFilePickerState> {
   private fileBrowserService: FileBrowserService;
@@ -51,7 +52,7 @@ export class FilePicker extends React.Component<IFilePickerProps, IFilePickerSta
   public async componentDidMount() {
     // Load information about Organisation Assets Library
     let orgAssetsEnabled: boolean = false;
-    if (this.props.hideOrganisationalAssetTab !== undefined && !this.props.hideOrganisationalAssetTab) {
+    if (!this.props.hideOrganisationalAssetTab) {
       const orgAssetsLibraries = await this.orgAssetsService.getSiteMediaLibraries();
       orgAssetsEnabled = orgAssetsLibraries ? true : false;
     }
@@ -117,6 +118,14 @@ export class FilePicker extends React.Component<IFilePickerProps, IFilePickerSta
               <LinkFilePickerTab
                 fileSearchService={this.fileSearchService}
                 allowExternalTenantLinks={true}
+                {...linkTabProps}
+              />
+            }
+            {
+              this.state.selectedTab === "keyStockImages" &&
+              <StockImages
+                language={this.props.context.pageContext.cultureInfo.currentCultureName}
+                fileSearchService={this.fileSearchService}
                 {...linkTabProps}
               />
             }
@@ -229,6 +238,14 @@ export class FilePicker extends React.Component<IFilePickerProps, IFilePickerSta
         url: addUrl ? '#recent' : undefined,
         icon: 'Recent',
         key: 'keyRecent',
+      });
+    }
+    if (!this.props.hideStockImages) {
+      links.push({
+        name: strings.StockImagesLinkLabel,
+        url: addUrl ? '#stockImages' : undefined,
+        key: 'keyStockImages',
+        icon: 'ImageSearch',
       });
     }
     if (this.props.bingAPIKey && !this.props.hideWebSearchTab) {

--- a/src/propertyFields/filePicker/filePickerControls/IFilePickerProps.ts
+++ b/src/propertyFields/filePicker/filePickerControls/IFilePickerProps.ts
@@ -106,4 +106,9 @@ export interface IFilePickerProps {
   filePickerResult: IFilePickerResult;
   
   context: WebPartContext;
+
+  /**
+   * Specifies if StockImagesTab should be hidden.
+   */
+  hideStockImages?: boolean;
 }

--- a/src/propertyFields/filePicker/filePickerControls/StockImagesTab/IStockImagesProps.ts
+++ b/src/propertyFields/filePicker/filePickerControls/StockImagesTab/IStockImagesProps.ts
@@ -1,0 +1,7 @@
+import { IFilePickerTab } from "..";
+import { FilesSearchService } from "../../../../services/FilesSearchService";
+
+export interface IStockImagesProps extends IFilePickerTab {
+  language: string;
+  fileSearchService: FilesSearchService;
+}

--- a/src/propertyFields/filePicker/filePickerControls/StockImagesTab/StockImages.module.scss
+++ b/src/propertyFields/filePicker/filePickerControls/StockImagesTab/StockImages.module.scss
@@ -1,0 +1,18 @@
+@import "../FilePicker.module.scss";
+
+.stockImagesPickerContainer {
+  width: 100%;
+  height: 100%;
+}
+.stockImagesPicker {
+  width: 100%;
+  height: 100%;
+
+  background-color: transparent;
+  border: 0px none transparent;
+  padding: 0px;
+  overflow: hidden;
+
+  margin-top:-30px;
+  margin-left: -35px;
+}

--- a/src/propertyFields/filePicker/filePickerControls/StockImagesTab/StockImages.tsx
+++ b/src/propertyFields/filePicker/filePickerControls/StockImagesTab/StockImages.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import styles from './StockImages.module.scss';
+import { StockImagesEvent, SubmitValue, IStockImagesProps } from '.';
+import { GeneralHelper } from '../../../../helpers/GeneralHelper';
+import { IFilePickerResult } from '..';
+
+export class StockImages extends React.Component<IStockImagesProps> {
+  public componentDidMount() {
+    window.addEventListener("message", this._handleImageIframeEvent);
+  }
+
+  public componentWillUnmount() {
+    window.removeEventListener("message", this._handleImageIframeEvent);
+  }
+
+  public render(): React.ReactElement<IStockImagesProps> {
+    const { language } = this.props;
+
+    const themesColor = `&themecolors=${encodeURIComponent(this.getCurrentThemeConfiguration())}`;
+    const contentPickerUrl = `https://hubblecontent.osi.office.net/contentsvc/external/m365contentpicker/index.html?p=3&app=1001&aud=prod&channel=devmain&setlang=${language}&msel=0&env=prod&premium=1${themesColor}`;
+
+    return (
+      <div className={styles.tabContainer}>
+        <div className={styles.tab}>
+          <div className={styles.stockImagesPickerContainer}>
+            <iframe className={styles.stockImagesPicker} role={"application"} id={"stockImagesIFrame"}
+            src={contentPickerUrl} />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  private _handleImageIframeEvent = (event) => {
+    if (!event || !event.origin || event.origin.indexOf("https://hubblecontent.osi.office.net") !== 0) {
+      return;
+    }
+
+    const eventData: StockImagesEvent = JSON.parse(event.data);
+
+    if (eventData.MessageId === "AddItem") {
+      this._handleSave(eventData);
+    } else if (eventData.MessageId === "CancelDialog") {
+      this._handleClose();
+    } 
+  }
+
+  /**
+   * Called when user saves
+   */
+  private _handleSave = (event: StockImagesEvent) => {
+    let filePickerResult: IFilePickerResult = null;
+    const cdnFileInfo: SubmitValue = event.Values && (event.Values as SubmitValue[]).length > 0 ? (event.Values as SubmitValue[])[0] : null;
+    if (cdnFileInfo) {
+      filePickerResult = {
+        downloadFileContent: () => { return this.props.fileSearchService.downloadBingContent(cdnFileInfo.sourceUrl, GeneralHelper.getFileNameFromUrl(GeneralHelper.getFileNameFromUrl(cdnFileInfo.sourceUrl))); },
+        fileAbsoluteUrl: cdnFileInfo.sourceUrl,
+        fileName: GeneralHelper.getFileNameFromUrl(cdnFileInfo.sourceUrl),
+        fileNameWithoutExtension: GeneralHelper.getFileNameWithoutExtension(cdnFileInfo.sourceUrl)
+      };
+    }
+    
+    this.props.onSave(filePickerResult);
+  }
+
+  /**
+   * Called when user closes tab
+   */
+  private _handleClose = () => {
+    this.props.onClose();
+  }
+
+  private getCurrentThemeConfiguration() {
+    if (!window["__themeState__"] || !window["__themeState__"].theme) {
+      return "";
+    }
+
+    const primaryColor = window["__themeState__"].theme["themePrimary"];
+    const textColor = window["__themeState__"].theme["primaryText"];
+    const primaryBackground = window["__themeState__"].theme["bodyBackground"]; 
+    const neutralLighter = window["__themeState__"].theme["neutralLighter"]; 
+
+    const theme = `{"primaryColor":"${primaryColor}","textColor":"${textColor}","backgroundColor":"${primaryBackground}","neutralLighterColor":"${neutralLighter}"}`;
+    return theme;
+  }
+}

--- a/src/propertyFields/filePicker/filePickerControls/StockImagesTab/StockImagesModel.ts
+++ b/src/propertyFields/filePicker/filePickerControls/StockImagesTab/StockImagesModel.ts
@@ -1,0 +1,35 @@
+export interface EventFlags {
+    dataCategories: number;
+    diagnosticLevel: number;
+  }
+  
+  export interface DataField {
+    name: string;
+    dataType: number;
+    value: string;
+    classification: number;
+  }
+  
+  export interface TelemetryProperties {
+    ariaTenantToken: string;
+    nexusTenantToken: number;
+  }
+  
+  export interface EventValue {
+    eventName: string;
+    eventFlags: EventFlags;
+    dataFields: DataField[];
+    telemetryProperties: TelemetryProperties;
+  }
+  export interface SubmitValue {
+    action: string;
+    contenttype: string;
+    sourceUrl: string;
+    caption: string;
+  }
+  
+  export interface StockImagesEvent {
+    MessageId: string;
+    Values: EventValue | SubmitValue[];
+    SendTime: number;
+  }

--- a/src/propertyFields/filePicker/filePickerControls/StockImagesTab/index.ts
+++ b/src/propertyFields/filePicker/filePickerControls/StockImagesTab/index.ts
@@ -1,0 +1,3 @@
+export * from "./StockImagesModel";
+export * from "./IStockImagesProps";
+export * from "./StockImages";

--- a/src/propertyFields/number/PropertyFieldNumberHost.tsx
+++ b/src/propertyFields/number/PropertyFieldNumberHost.tsx
@@ -84,7 +84,7 @@ export default class PropertyFieldNumberHost extends React.Component<IPropertyFi
       nrValue = parseFloat(value);
     }
     else if (precision === 0) {
-      nrValue = parseInt(value)
+      nrValue = parseInt(value);
     }
     else {
       const multiplier = Math.pow(10, precision);

--- a/src/services/OrgAssetsService.ts
+++ b/src/services/OrgAssetsService.ts
@@ -73,7 +73,7 @@ export class OrgAssetsService extends FileBrowserService {
       absoluteUrl: this.buildAbsoluteUrl(libItem.LibraryUrl.DecodedUrl),
       title: libItem.DisplayName,
       serverRelativeUrl: libItem.LibraryUrl.DecodedUrl,
-      iconPath: libItem.ThumbnailUrl.DecodedUrl ? this.buildAbsoluteUrl(`${this._orgAssetsLibraryServerRelativeSiteUrl}/${libItem.ThumbnailUrl.DecodedUrl}`) : null
+      iconPath: libItem.ThumbnailUrl && libItem.ThumbnailUrl.DecodedUrl ? this.buildAbsoluteUrl(`${this._orgAssetsLibraryServerRelativeSiteUrl}/${libItem.ThumbnailUrl.DecodedUrl}`) : null
     };
 
     return orgAssetsLibrary;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [x]
| New sample?      | [ ]
| Related issues?  | NA

#### What's in this Pull Request?

1) Added support for stock images in the file picker property pane control
2) Minor fix in org assets - additional null check for thumbnail of libraries
3) Minor TSlint fix for number control - added semicolon