### PR TITLE
Add areTermsSelectable and areTermsHidden properties to TermPicker

### DIFF
--- a/docs/documentation/docs/controls/PropertyFieldTermPicker.md
+++ b/docs/documentation/docs/controls/PropertyFieldTermPicker.md
@@ -84,6 +84,8 @@ The `PropertyFieldTermPicker` control can be configured with the following prope
 | limitByTermsetNameOrID | string | no | Limit the terms that can be picked by the Term Set name or ID. |
 | hideTermStoreName | boolean | no | Specifies if you want to show or hide the term store name from the panel. |
 | isTermSetSelectable | boolean | no | Specify if the term set itself is selectable in the tree view. |
+| areTermsSelectable | boolean | yes | Specify if the terms are selectable in the tree view. |
+| areTermsHidden | boolean | no | Specify if the terms are hidden from the tree view. |
 | disabledTermIds | string[] | no | Specify which terms should be disabled in the term set so that they cannot be selected. |
 | onPropertyChange | function | yes | Defines a onPropertyChange function to raise when the date gets changed. |
 | properties | any | yes | Parent web part properties, this object is use to update the property value.  |

--- a/src/loc/de-de.js
+++ b/src/loc/de-de.js
@@ -61,6 +61,7 @@ define([], () => {
   "TermPickerExpandTitle": "Erweitern dieses Begriffssatzes",
   "TermPickerExpandNode": "Erweitern dieses Knotens",
   "TermPickerMenuTermSet": "Menü für Term Set",
+  "TermPickerMenuTerm": "Menü für Term",
   "TermPickerMenuGroup": "Menü für Term Group",
   "TermPickerInLabel": "In",
   "TermPickerTermSetLabel": "Begriffssatz",

--- a/src/loc/en-us.js
+++ b/src/loc/en-us.js
@@ -61,6 +61,7 @@ define([], function () {
     TermPickerExpandTitle: "Expand this Term Set",
     TermPickerExpandNode: "Expand this Node",
     TermPickerMenuTermSet: "Menu for Term Set",
+    TermPickerMenuTerm: "Menu for Term",
     TermPickerMenuGroup: "Menu for Term Group",
     TermPickerInLabel: "in",
     TermPickerTermSetLabel: "Term Set",

--- a/src/loc/mystrings.d.ts
+++ b/src/loc/mystrings.d.ts
@@ -70,6 +70,7 @@ declare interface IPropertyControlStrings {
   TermPickerNoTerms: string;
   TermPickerExpandTitle: string;
   TermPickerExpandNode: string;
+  TermPickerMenuTerm: string;
   TermPickerMenuTermSet: string;
   TermPickerMenuGroup: string;
   TermPickerInLabel: string;

--- a/src/loc/pl-pl.js
+++ b/src/loc/pl-pl.js
@@ -61,6 +61,7 @@ define([], () => {
   "TermPickerExpandTitle": "Rozwiń ten zestaw terminów",
   "TermPickerExpandNode": "Rozwiń ten węzeł",
   "TermPickerMenuTermSet": "Menu dla zestawu terminów",
+  "TermPickerMenuTerm": "Menu dla terminów",
   "TermPickerMenuGroup": "Menu dla grupy termów",
   "TermPickerInLabel": "Cala",
   "TermPickerTermSetLabel": "Zestaw terminów",

--- a/src/propertyFields/termPicker/IPropertyFieldTermPicker.ts
+++ b/src/propertyFields/termPicker/IPropertyFieldTermPicker.ts
@@ -146,6 +146,14 @@ export interface IPropertyFieldTermPickerProps {
    */
   isTermSetSelectable?: boolean;
   /**
+   * Specify if terms are selectable in the tree view
+   */
+  areTermsSelectable?: boolean;
+  /**
+   * Specify if terms are hidden from the tree view
+   */
+  areTermsHidden?: boolean;
+  /**
    * Specify which terms should be disabled in the term set so that they cannot be selected
    */
   disabledTermIds?: string[];

--- a/src/propertyFields/termPicker/IPropertyFieldTermPickerHost.ts
+++ b/src/propertyFields/termPicker/IPropertyFieldTermPickerHost.ts
@@ -31,6 +31,8 @@ export interface ITermGroupProps extends ITermChanges {
   termsService: ISPTermStorePickerService;
   multiSelection: boolean;
   isTermSetSelectable?: boolean;
+  areTermsSelectable?: boolean;
+  areTermsHidden?: boolean;
   disabledTermIds?: string[];
 }
 
@@ -47,6 +49,8 @@ export interface ITermSetProps extends ITermChanges {
   autoExpand: () => void;
   multiSelection: boolean;
   isTermSetSelectable?: boolean;
+  areTermsSelectable?: boolean;
+  areTermsHidden?: boolean;
   disabledTermIds?: string[];
 }
 
@@ -62,6 +66,7 @@ export interface ITermProps extends ITermChanges {
   term: ITerm;
   multiSelection: boolean;
   disabled: boolean;
+  isTermSelectable: boolean;
 }
 
 export interface ITermState {

--- a/src/propertyFields/termPicker/PropertyFieldTermPicker.ts
+++ b/src/propertyFields/termPicker/PropertyFieldTermPicker.ts
@@ -33,6 +33,8 @@ export class PropertyFieldTermPickerBuilder implements IPropertyPaneField<IPrope
   private panelTitle: string;
   private hideTermStoreName: boolean;
   private isTermSetSelectable: boolean;
+  private areTermsSelectable: boolean = true;
+  private areTermsHidden: boolean;
   private disabledTermIds: string[];
   private termService: ISPTermStorePickerService;
 
@@ -63,9 +65,10 @@ export class PropertyFieldTermPickerBuilder implements IPropertyPaneField<IPrope
     this.limitByTermsetNameOrID = _properties.limitByTermsetNameOrID;
     this.hideTermStoreName = _properties.hideTermStoreName;
     this.isTermSetSelectable = _properties.isTermSetSelectable;
+    this.areTermsHidden = _properties.areTermsHidden;
     this.disabledTermIds = _properties.disabledTermIds;
     this.termService = _properties.termService;
-
+    
     if (_properties.disabled === true) {
       this.disabled = _properties.disabled;
     }
@@ -80,6 +83,9 @@ export class PropertyFieldTermPickerBuilder implements IPropertyPaneField<IPrope
     }
     if (typeof _properties.excludeSystemGroup !== 'undefined') {
       this.excludeSystemGroup = _properties.excludeSystemGroup;
+    }
+    if (typeof _properties.areTermsSelectable !== 'undefined') {
+      this.areTermsSelectable =_properties.areTermsSelectable;
     }
   }
 
@@ -99,6 +105,8 @@ export class PropertyFieldTermPickerBuilder implements IPropertyPaneField<IPrope
       limitByTermsetNameOrID: this.limitByTermsetNameOrID,
       hideTermStoreName: this.hideTermStoreName,
       isTermSetSelectable: this.isTermSetSelectable,
+      areTermsSelectable: this.areTermsSelectable,
+      areTermsHidden: this.areTermsHidden,
       disabledTermIds: this.disabledTermIds,
       context: this.context,
       onDispose: this.dispose,

--- a/src/propertyFields/termPicker/PropertyFieldTermPickerHost.module.scss
+++ b/src/propertyFields/termPicker/PropertyFieldTermPickerHost.module.scss
@@ -34,6 +34,10 @@
   margin-left: 15px;
 }
 
+.termsHidden {
+  display: none;
+}
+
 .termSetSelectable {
   height: 50px;
   line-height: 50px;

--- a/src/propertyFields/termPicker/PropertyFieldTermPickerHost.tsx
+++ b/src/propertyFields/termPicker/PropertyFieldTermPickerHost.tsx
@@ -23,7 +23,7 @@ export const COLLAPSED_IMG = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA8A
 export const EXPANDED_IMG = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA8AAAAUCAYAAABSx2cSAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAABh0RVh0U29mdHdhcmUAUGFpbnQuTkVUIHYzLjEwcrIlkgAAAFtJREFUOE9j/P//PwPZAKSZXEy2RrCLybV1CGjetWvX/46ODqBLUQOXoJ9BGtXU1MCYJM0wjZGRkaRpRtZIkmZ0jSRpBgUOzJ8wmqwAw5eICIb2qGYSkyfNAgwAasU+UQcFvD8AAAAASUVORK5CYII='; // /_layouts/15/images/MDNExpanded.png
 export const GROUP_IMG = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAC9SURBVDhPY2CgNXh1qEkdiJ8D8X90TNBuJM0V6IpBhoHFgIxebKYTIwYzAMNpxGhGdsFwNoBgNEFjAWsYgOSKiorMgPgbEP/Hgj8AxXpB0Yg1gQAldYuLix8/efLkzn8s4O7du9eAan7iM+DV/v37z546der/jx8/sJkBdhVOA5qbm08ePnwYrOjQoUOkGwDU+AFowLmjR4/idwGukAYaYAkMgxfPnj27h816kDg4DPABoAI/IP6DIxZA4l0AOd9H3QXl5+cAAAAASUVORK5CYII='; // /_layouts/15/Images/EMMGroup.png
 export const TERMSET_IMG = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACaSURBVDhPrZLRCcAgDERdpZMIjuQA7uWH4CqdxMY0EQtNjKWB0A/77sxF55SKMTalk8a61lqCFqsLiwKac84ZRUUBi7MoYHVmAfjfjzE6vJqZQfie0AcwBQVW8ATi7AR7zGGGNSE6Q2cyLSPIjRswjO7qKhcPDN2hK46w05wZMcEUIG+HrzzcrRsQBIJ5hS8C9fGAPmRwu/9RFxW6L8CM4Ry8AAAAAElFTkSuQmCC'; // /_layouts/15/Images/EMMTermSet.png
-
+export const TERM_IMG = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAZBJREFUeNqkU0trwkAQnhURBBFPKghekuJN7KW9pOCj0Agl9/4uT/6BHgXpxQfxYKltKEYhV3tXFF/4RrOdXYgkxpz8YA47O983O9+whFIKt8DvddHv9wej0UjY7/dwPB55sGaJRKImSVLxXMiSl9Hr9fRWq0WvoVKpUFVVv6xaF1nX9R+LvFqteKAgrVarVNM0fi6Xy9Sq99mfjeTv2Wz2mMvlYL1en/OGYYCiKKTT6fAzG8flQbfb1ReLxX0+n4fJZOLwQxRFKJVKNJPJwHa7dZuI5I/lcsnJrHMwGHQUpdNpHp5bGI/Hr7IsA3Pc7/dcDEynU5jP5xAIBJwCpmmeN+IF9IaT0VA20p+V5yaGQqF2s9mE3W4Hh8PBFXZyLBbTstmsaAkQqyuu7nOz2UiCIEAkEoFwOMzz6A0n44YgHo8bhULBYQaxP7vRaLyjyFsqleIiDLbOAyTfXY5GLueu1+s1XNULE2Fg5Gg0qj4jrnlDrhmHIu3hcPh0Op0gmUz+IvfBy1xy62/0wY34F2AAKtctO7g/KgIAAAAASUVORK5CYII='
 
 /**
  * Renders the controls for PropertyFieldTermPicker component
@@ -286,6 +286,8 @@ export default class PropertyFieldTermPickerHost extends React.Component<IProper
                   value={this.state.activeNodes}
                   onChanged={this.termsFromPickerChanged}
                   allowMultipleSelections={this.props.allowMultipleSelections}
+                  areTermsSelectable={this.props.areTermsSelectable}
+                  areTermsHidden={this.props.areTermsHidden}
                   isTermSetSelectable={this.props.isTermSetSelectable}
                   disabledTermIds={this.props.disabledTermIds}
                   termsService={this.termsService}
@@ -343,6 +345,8 @@ export default class PropertyFieldTermPickerHost extends React.Component<IProper
                         changedCallback={this.termsChanged}
                         multiSelection={this.props.allowMultipleSelections}
                         isTermSetSelectable={this.props.isTermSetSelectable}
+                        areTermsSelectable={this.props.areTermsSelectable}
+                        areTermsHidden={this.props.areTermsHidden}
                         disabledTermIds={this.props.disabledTermIds} />;
                     })
                   }

--- a/src/propertyFields/termPicker/Term.tsx
+++ b/src/propertyFields/termPicker/Term.tsx
@@ -3,6 +3,8 @@ import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
 import { ITermProps, ITermState } from './IPropertyFieldTermPickerHost';
 
 import styles from './PropertyFieldTermPickerHost.module.scss';
+import * as strings from 'PropertyControlStrings';
+import { TERM_IMG } from './PropertyFieldTermPickerHost';
 
 
 /**
@@ -71,12 +73,18 @@ export default class Term extends React.Component<ITermProps, ITermState> {
 
     return (
       <div className={`${styles.listItem} ${styles.term}`} style={styleProps}>
-        <Checkbox
-          checked={this.state.selected}
-          disabled={this.props.term.IsDeprecated || !this.props.term.IsAvailableForTagging || this.props.disabled}
-          className={this.getClassName()}
-          label={this.props.term.Name}
-          onChange={this._handleChange} />
+        {
+          this.props.isTermSelectable ?
+          <Checkbox
+            checked={this.state.selected}
+            disabled={this.props.term.IsDeprecated || !this.props.term.IsAvailableForTagging || this.props.disabled}
+            className={this.getClassName()}
+            label={this.props.term.Name}
+            onChange={this._handleChange} /> :
+          (<div>
+            <img src={TERM_IMG} alt={strings.TermPickerMenuTerm} title={strings.TermPickerMenuTerm} /> {this.props.term.Name}
+          </div>)
+        }
       </div>
     );
   }

--- a/src/propertyFields/termPicker/TermGroup.tsx
+++ b/src/propertyFields/termPicker/TermGroup.tsx
@@ -96,6 +96,8 @@ export default class TermGroup extends React.Component<ITermGroupProps, ITermGro
                 changedCallback={this.props.changedCallback}
                 multiSelection={this.props.multiSelection}
                 isTermSetSelectable={this.props.isTermSetSelectable}
+                areTermsSelectable={this.props.areTermsSelectable}
+                areTermsHidden={this.props.areTermsHidden}
                 disabledTermIds={this.props.disabledTermIds} />;
             }) : <Spinner type={SpinnerType.normal} />
           }

--- a/src/propertyFields/termPicker/TermPicker.tsx
+++ b/src/propertyFields/termPicker/TermPicker.tsx
@@ -22,6 +22,8 @@ export interface ITermPickerProps {
   disabled: boolean;
   value: IPickerTerms;
   allowMultipleSelections: boolean;
+  areTermsSelectable: boolean;
+  areTermsHidden: boolean;
   isTermSetSelectable: boolean;
   disabledTermIds: string[];
   onChanged: (items: IPickerTerm[]) => void;

--- a/src/propertyFields/termPicker/TermSet.tsx
+++ b/src/propertyFields/termPicker/TermSet.tsx
@@ -43,6 +43,9 @@ export default class TermSet extends React.Component<ITermSetProps, ITermSetStat
    * Handle the click event: collapse or expand
    */
   private _handleClick() {
+    if (this.props.areTermsHidden) {
+      return;
+    }
     this.setState({
       expanded: !this.state.expanded
     });
@@ -59,7 +62,9 @@ export default class TermSet extends React.Component<ITermSetProps, ITermSetStat
     // Check if there are already terms loaded
     if (!this.state.loaded) {
       // Receive all the terms for the current term set
-      const terms: ITerm[] = await this.props.termsService.getAllTerms(this.props.termset);
+      const terms: ITerm[] = this.props.areTermsHidden
+        ? null
+        : await this.props.termsService.getAllTerms(this.props.termset);
       if (terms !== null) {
         this.setState({
           terms: terms,
@@ -122,7 +127,8 @@ export default class TermSet extends React.Component<ITermSetProps, ITermSetStat
                     activeNodes={this.props.activeNodes}
                     changedCallback={this.props.changedCallback}
                     multiSelection={this.props.multiSelection}
-                    disabled={disabled} />;
+                    disabled={disabled}
+                    isTermSelectable={this.props.areTermsSelectable} />;
                 })
               }
             </div>
@@ -137,8 +143,8 @@ export default class TermSet extends React.Component<ITermSetProps, ITermSetStat
 
     return (
       <div>
-        <div className={`${styles.listItem} ${styles.termset} ${this.props.isTermSetSelectable ? styles.termSetSelectable : ""}`} onClick={this._handleClick}>
-          <img src={this.state.expanded ? EXPANDED_IMG : COLLAPSED_IMG} alt={strings.TermPickerExpandTitle} title={strings.TermPickerExpandTitle} />
+        <div className={`${styles.listItem} ${styles.termset} ${this.props.isTermSetSelectable && !this.props.areTermsHidden ? styles.termSetSelectable : ""}`} onClick={this._handleClick}>
+          <img className={`${this.props.areTermsHidden ? styles.termsHidden : ""}`} src={this.state.expanded ? EXPANDED_IMG : COLLAPSED_IMG} alt={strings.TermPickerExpandTitle} title={strings.TermPickerExpandTitle} />
 
           {
             // Show the termset selection box


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ X ]
| New sample?      | [ ]
| Related issues?  | mentioned in #307 

#### What's in this Pull Request?

PR adds two properties to TermPicker control: areTermsSelectable and areTermsHidden. 
I guess their names are self-explanatory :)
