### PR TITLE
Add "options" property to CodeEditor

### DIFF
--- a/docs/documentation/docs/controls/PropertyFieldCodeEditor.md
+++ b/docs/documentation/docs/controls/PropertyFieldCodeEditor.md
@@ -38,7 +38,12 @@ PropertyFieldCodeEditor('htmlCode', {
   properties: this.properties,
   disabled: false,
   key: 'codeEditorFieldId',
-  language: PropertyFieldCodeEditorLanguages.HTML
+  language: PropertyFieldCodeEditorLanguages.HTML,
+  options: {
+    wrap: true,
+    fontSize: 20,
+    // more options
+  }
 })
 ```
 
@@ -56,6 +61,7 @@ The `PropertyFieldCodeEditor` control can be configured with the following prope
 | properties | any | yes | Parent web part properties, this object is use to update the property value.  |
 | onPropertyChange | function | yes | Defines a onPropertyChange function to raise when the date gets changed. |
 | key | string | yes | An unique key that indicates the identity of this control. |
+| options | AceOptions | no | [Additional properties](https://github.com/ajaxorg/ace/wiki/Configuring-Ace) available to the Ace editor. |
 
 Enum `PropertyFieldCodeEditorLanguages`
 

--- a/src/propertyFields/codeEditor/IPropertyFieldCodeEditor.ts
+++ b/src/propertyFields/codeEditor/IPropertyFieldCodeEditor.ts
@@ -1,4 +1,5 @@
 import { IWebPartContext } from '@microsoft/sp-webpart-base';
+import { AceOptions } from 'react-ace';
 
 
 export enum PropertyFieldCodeEditorLanguages {
@@ -60,6 +61,10 @@ export interface IPropertyFieldCodeEditorProps {
    * Default value is 200.
    */
   deferredValidationTime?: number;
+  /**
+   * Additional properties available to the Ace editor
+   */
+  options?: AceOptions;
 }
 
 /**

--- a/src/propertyFields/codeEditor/PropertyFieldCodeEditor.ts
+++ b/src/propertyFields/codeEditor/PropertyFieldCodeEditor.ts
@@ -8,6 +8,7 @@ import {
 import PropertyFieldCodeEditorHost from './PropertyFieldCodeEditorHost';
 import { IPropertyFieldCodeEditorHostProps } from './IPropertyFieldCodeEditorHost';
 import { IPropertyFieldCodeEditorPropsInternal, IPropertyFieldCodeEditorProps, PropertyFieldCodeEditorLanguages } from './IPropertyFieldCodeEditor';
+import { AceOptions } from 'react-ace';
 
 /**
  * Represents a PropertyFieldCodeEditor object
@@ -31,6 +32,7 @@ class PropertyFieldCodeEditorBuilder implements IPropertyPaneField<IPropertyFiel
   private key: string;
   private disabled: boolean = false;
   private deferredValidationTime: number = 200;
+  private options: AceOptions;
 
   /**
    * Constructor method
@@ -57,6 +59,9 @@ class PropertyFieldCodeEditorBuilder implements IPropertyPaneField<IPropertyFiel
     if (_properties.deferredValidationTime) {
       this.deferredValidationTime = _properties.deferredValidationTime;
     }
+    if (_properties.options) {
+      this.options = _properties.options;
+    }
 
   }
 
@@ -78,7 +83,8 @@ class PropertyFieldCodeEditorBuilder implements IPropertyPaneField<IPropertyFiel
       properties: this.customProperties,
       key: this.key,
       disabled: this.disabled,
-      deferredValidationTime: this.deferredValidationTime
+      deferredValidationTime: this.deferredValidationTime,
+      options: this.options,
     });
 
     // Calls the REACT content generator

--- a/src/propertyFields/codeEditor/PropertyFieldCodeEditorHost.tsx
+++ b/src/propertyFields/codeEditor/PropertyFieldCodeEditorHost.tsx
@@ -232,6 +232,7 @@ export default class PropertyFieldCodeEditorHost extends React.Component<IProper
             value={this.state.code}
             name={`code-${this.props.targetProperty}`}
             editorProps={{ $blockScrolling: true }}
+            setOptions={this.props.options}
           />
         </Panel>
       </div>

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
@@ -980,7 +980,11 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                   properties: this.properties,
                   disabled: false,
                   key: 'codeEditorFieldId',
-                  language: PropertyFieldCodeEditorLanguages.HTML
+                  language: PropertyFieldCodeEditorLanguages.HTML,
+                  // options: {
+                  //   wrap: true,
+                  //   fontSize: 20,
+                  // }
                 }),
                 PropertyFieldCollectionData("collectionData", {
                   key: "collectionData",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [X]
| New sample?      | [ ]
| Related issues?  | fixes #316 

#### What's in this Pull Request?

Added an "options" property to the CodeEditor. Allows setting of any of the Ace Editor options outlined here: https://github.com/ajaxorg/ace/wiki/Configuring-Ace

This allows for more flexibility than only adding the `wrapEnabled` editor property.

Example Usage:
```
PropertyFieldCodeEditor('htmlCode', {
  label: 'Edit HTML Code',
  panelTitle: 'Edit HTML Code',
  initialValue: this.properties.htmlCode,
  onPropertyChange: this.onPropertyPaneFieldChanged,
  properties: this.properties,
  disabled: false,
  key: 'codeEditorFieldId',
  language: PropertyFieldCodeEditorLanguages.HTML,
  options: {
     wrap: true,
     fontSize: 20,
  }
}),
```
