### PR TITLE
Merge for v2.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/sp-dev-fx-property-controls
   docker:
-    - image: circleci/node:12.15.0
+    - image: circleci/node:10.22.0
 
 version: 2
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/sp-dev-fx-property-controls
   docker:
-    - image: circleci/node:10.22.0
+    - image: circleci/node:12.15.0
 
 version: 2
 jobs:
@@ -26,12 +26,6 @@ jobs:
       - run:
           name: build
           command: npm run build
-      - run:
-          name: sonarcloud:config
-          command: npm run sonarcloud:config $SONARCLOUD_TOKEN $CIRCLE_BRANCH
-      - run:
-          name: sonarcloud:start
-          command: npm run sonarcloud:start
       - persist_to_workspace:
           root: .
           paths: .
@@ -104,7 +98,7 @@ workflows:
       - build:
           filters:
             branches:
-              ignore: /^(dev|master|v2)/
+              ignore: /^(dev|master|v2|v2-dev)/
   release_next:
     jobs:
       - build:
@@ -113,6 +107,7 @@ workflows:
               only:
                 - dev
                 - v2
+                - v2-dev
       - build_next:
           requires:
             - build
@@ -121,6 +116,7 @@ workflows:
               only:
                 - dev
                 - v2
+                - v2-dev
       - publish_next:
           requires:
             - build_next
@@ -129,6 +125,7 @@ workflows:
               only:
                 - dev
                 - v2
+                - v2-dev
   release:
     jobs:
       - build:

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -9,6 +9,7 @@
           "`PropertyFieldSitePicker`: Site Picker doesn't return sites with title starting from the typed string [#355](https://github.com/pnp/sp-dev-fx-property-controls/issues/355)"
         ]
       }
+      "contributions": []
     },
     {
       "version": "2.5.0",

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,6 +1,16 @@
 {
   "versions": [
     {
+      "version": "2.6.0",
+      "changes": {
+        "new": [],
+        "enhancements": [],
+        "fixes": [
+          "`PropertyFieldSitePicker`: Site Picker doesn't return sites with title starting from the typed string [#355](https://github.com/pnp/sp-dev-fx-property-controls/issues/355)"
+        ]
+      }
+    },
+    {
       "version": "2.5.0",
       "changes": {
         "new": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnp/spfx-property-controls",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pnp/spfx-property-controls",
   "description": "Reusable property pane controls for SharePoint Framework solutions",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "engines": {
     "node": ">=0.10.0"
   },

--- a/src/services/SPSiteSearchService.ts
+++ b/src/services/SPSiteSearchService.ts
@@ -24,7 +24,7 @@ export default class SPSiteSearchService implements ISPSiteSearchService {
       }
 
       // If the running env is SharePoint, loads from the search
-      const userRequestUrl: string = `${ctx.pageContext.web.absoluteUrl}/_api/search/query?querytext='contentclass:STS_Site contentclass:STS_Web Title:*${query}* Path:${rootUrl}*'&selectproperties='SiteId,SiteID,WebId,Title,Path'&rowlimit=5`;
+      const userRequestUrl: string = `${ctx.pageContext.web.absoluteUrl}/_api/search/query?querytext='contentclass:STS_Site contentclass:STS_Web Title:${query}* Path:${rootUrl}*'&selectproperties='SiteId,SiteID,WebId,Title,Path'&rowlimit=5`;
 
       // Do the call against the SP REST API search endpoint
       return ctx.spHttpClient.get(userRequestUrl, SPHttpClient.configurations.v1).then((searchResponse: SPHttpClientResponse) => {


### PR DESCRIPTION
### New control(s)

- `DragDropFiles`: new DragDropFiles control [#856](https://github.com/pnp/sp-dev-fx-controls-react/issues/856)
- `SitePicker` new Site Picker control [#867](https://github.com/pnp/sp-dev-fx-controls-react/pull/867)
- `Controls` Add locale strings for pt-br [#865](https://github.com/pnp/sp-dev-fx-controls-react/pull/865)

### Enhancements

- `ListView`: Use new DragDropFiles control [#856](https://github.com/pnp/sp-dev-fx-controls-react/issues/856)
- `FilePicker`: Use new DragDropFiles control [#856](https://github.com/pnp/sp-dev-fx-controls-react/issues/856)
- `ListView`: Ability to provide custom sorting function [#880](https://github.com/pnp/sp-dev-fx-controls-react/issues/880)
- `FilePicker`: Allow panel on FilePicker to be invoked after first load [#886](https://github.com/pnp/sp-dev-fx-controls-react/issues/886)
- `FilePicker`: Allow FilePicker button to be hidden [#887](https://github.com/pnp/sp-dev-fx-controls-react/issues/887)
- `FilePicker`: Changed save function to return an array of objects

### Fixes

- `PeoplePicker`: error message isn't cleared after `onGetErrorMessage` returns an empty string [#841](https://github.com/pnp/sp-dev-fx-controls-react/issues/841)
- `TreeView`: Not able to select/deselect checkbox in spfx-controls-react TreeView after assign the defaultSelectedKeys value [#870](https://github.com/pnp/sp-dev-fx-controls-react/issues/870)
- `FilePicker`: React crash on large folders [#826](https://github.com/pnp/sp-dev-fx-controls-react/issues/826)
- `ListItemAttachments`: updated filename replacement logic [#873](https://github.com/pnp/sp-dev-fx-controls-react/pull/873)
- `RichText`: Adding a link does not work [#875](https://github.com/pnp/sp-dev-fx-controls-react/issues/875)
- `FilePicker`: Stock images url is getting a 404 server error [#882](https://github.com/pnp/sp-dev-fx-controls-react/issues/882)