### PR TITLE
Updated changelog

### DIFF
--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+if [ -z "$husky_skip_init" ]; then
+  debug () {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky (debug) - $1"
+  }
+
+  readonly hook_name="$(basename "$0")"
+  debug "starting $hook_name..."
+
+  if [ "$HUSKY" = "0" ]; then
+    debug "HUSKY env variable is set to 0, skipping hook"
+    exit 0
+  fi
+
+  if [ -f ~/.huskyrc ]; then
+    debug "sourcing ~/.huskyrc"
+    . ~/.huskyrc
+  fi
+
+  export readonly husky_skip_init=1
+  sh -e "$0" "$@"
+  exitCode="$?"
+
+  if [ $exitCode != 0 ]; then
+    echo "husky - $hook_name hook exited with code $exitCode (error)"
+    exit $exitCode
+  fi
+
+  exit 0
+fi

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -8,7 +8,7 @@
         "fixes": [
           "`PropertyFieldSitePicker`: Site Picker doesn't return sites with title starting from the typed string [#355](https://github.com/pnp/sp-dev-fx-property-controls/issues/355)"
         ]
-      }
+      },
       "contributions": []
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Releases
 
+## 2.6.0
+
+### Fixes
+
+- `PropertyFieldSitePicker`: Site Picker doesn't return sites with title starting from the typed string [#355](https://github.com/pnp/sp-dev-fx-property-controls/issues/355)
+
 ## 2.5.0
 
 ### New control(s)

--- a/docs/documentation/docs/about/release-notes.md
+++ b/docs/documentation/docs/about/release-notes.md
@@ -1,5 +1,11 @@
 # Releases
 
+## 2.6.0
+
+### Fixes
+
+- `PropertyFieldSitePicker`: Site Picker doesn't return sites with title starting from the typed string [#355](https://github.com/pnp/sp-dev-fx-property-controls/issues/355)
+
 ## 2.5.0
 
 ### New control(s)

--- a/src/common/telemetry/version.ts
+++ b/src/common/telemetry/version.ts
@@ -1,1 +1,1 @@
-export const version: string = "2.5.0";
+export const version: string = "2.6.0";


### PR DESCRIPTION
## 2.6.0

### Fixes

- `PropertyFieldSitePicker`: Site Picker doesn't return sites with title starting from the typed string [#355](https://github.com/pnp/sp-dev-fx-property-controls/issues/355)