### PR TITLE
Fix issue with file picker crashing modal

### DIFF
--- a/src/propertyFields/filePicker/filePickerControls/controls/FileBrowser/FileBrowser.tsx
+++ b/src/propertyFields/filePicker/filePickerControls/controls/FileBrowser/FileBrowser.tsx
@@ -179,7 +179,7 @@ export class FileBrowser extends React.Component<IFileBrowserProps, IFileBrowser
                         selectionPreservedOnEmptyClick={true}
                         enterModalSelectionOnTouch={true}
                         onRenderRow={this._onRenderRow}
-                        onRenderMissingItem={this._loadNextDataRequest}
+                        onRenderMissingItem={() => { this._loadNextDataRequest(); return null; }}
                       />) :
                       (<TilesList
                         fileBrowserService={this.props.fileBrowserService}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | same fix as [#826](https://github.com/pnp/sp-dev-fx-controls-react/issues/826)

#### What's in this Pull Request?

This PR fixes an issue in the FilePicker component where it crashes the file selection modal when scrolling through pages of items. This is the same fix that was merged into sp-dev-fx-controls-react to fix https://github.com/pnp/sp-dev-fx-controls-react/issues/826.