### PR TITLE
Fix TextWithCallout read-only in SPFx 1.12.1

### DIFF
--- a/src/propertyFields/textWithCallout/IPropertyFieldTextWithCallout.ts
+++ b/src/propertyFields/textWithCallout/IPropertyFieldTextWithCallout.ts
@@ -1,16 +1,19 @@
 import {
     IPropertyPaneCustomFieldProps,
     IPropertyPaneTextFieldProps
-} from '@microsoft/sp-webpart-base';
+} from '@microsoft/sp-property-pane';
 
 import { IPropertyFieldHeaderCalloutProps } from '../../common/propertyFieldHeader/IPropertyFieldHeader';
 
 export interface IPropertyFieldTextWithCalloutPropsInternal
-    extends IPropertyPaneCustomFieldProps, IPropertyPaneTextFieldProps, IPropertyFieldHeaderCalloutProps {}
+    extends IPropertyPaneCustomFieldProps, IPropertyPaneTextFieldProps, IPropertyFieldHeaderCalloutProps {
+        onChanged?: (newValue: any) => void;
+    }
 
 /**
  * Public properties of PropertyFieldTextWithCallout custom field
  */
 export interface IPropertyFieldTextWithCalloutProps extends IPropertyPaneTextFieldProps, IPropertyFieldHeaderCalloutProps {
     key: string;
+    onChanged?: (newValue: any) => void;
 }

--- a/src/propertyFields/textWithCallout/IPropertyFieldTextWithCalloutHost.ts
+++ b/src/propertyFields/textWithCallout/IPropertyFieldTextWithCalloutHost.ts
@@ -5,4 +5,5 @@ import { ITextFieldProps } from 'office-ui-fabric-react/lib/components/TextField
  * PropertyFieldTextWithCalloutHost properties interface
  */
 export interface IPropertyFieldTextWithCalloutHostProps extends ITextFieldProps, IPropertyFieldHeaderCalloutProps {
+    onChanged?: (newValue: any) => void;
 }

--- a/src/propertyFields/textWithCallout/PropertyFieldTextWithCallout.ts
+++ b/src/propertyFields/textWithCallout/PropertyFieldTextWithCallout.ts
@@ -3,7 +3,7 @@ import * as ReactDOM from 'react-dom';
 import {
     IPropertyPaneField,
     PropertyPaneFieldType
-} from '@microsoft/sp-webpart-base';
+} from '@microsoft/sp-property-pane';
 
 import PropertyFieldTextWithCalloutHost from './PropertyFieldTextWithCalloutHost';
 
@@ -24,6 +24,7 @@ class PropertyFieldTextWithCalloutBuilder implements IPropertyPaneField<IPropert
 
         this.properties.onRender = this._render.bind(this);
         this.properties.onDispose = this._dispose.bind(this);
+        this.properties.onChanged = this._onChanged.bind(this);
     }
 
     private _render(elem: HTMLElement, context?: any, changeCallback?: (targetProperty?: string, newValue?: any) => void): void {
@@ -32,7 +33,8 @@ class PropertyFieldTextWithCalloutBuilder implements IPropertyPaneField<IPropert
 
         const element = React.createElement(PropertyFieldTextWithCalloutHost, {
             ...omit(props, ['logName']),
-            onNotifyValidationResult: this._onValidated.bind(this)
+            onNotifyValidationResult: this._onValidated.bind(this),
+            onChanged: this._onChanged.bind(this)
         });
 
         ReactDOM.render(element, elem);
@@ -51,11 +53,18 @@ class PropertyFieldTextWithCalloutBuilder implements IPropertyPaneField<IPropert
             this._onChangeCallback(this.targetProperty, value);
         }
     }
+
+    private _onChanged(value: string): void {
+        if (this._onChangeCallback) {
+          this._onChangeCallback(this.targetProperty, value);
+        }
+      }
 }
 
 export function PropertyFieldTextWithCallout(targetProperty: string, properties: IPropertyFieldTextWithCalloutProps): IPropertyPaneField<IPropertyFieldTextWithCalloutPropsInternal> {
     return new PropertyFieldTextWithCalloutBuilder(targetProperty, {
         ...properties,
+        onChanged: properties.onChanged,
         onRender: null,
         onDispose: null
     });

--- a/src/propertyFields/textWithCallout/PropertyFieldTextWithCalloutHost.tsx
+++ b/src/propertyFields/textWithCallout/PropertyFieldTextWithCalloutHost.tsx
@@ -20,7 +20,7 @@ export default class PropertyFieldTextWithCalloutHost extends React.Component<IP
     return (
       <div>
         <PropertyFieldHeader {...this.props} />
-        <TextField { ...omit(this.props, ['label']) } />
+        <TextField {...omit(this.props, ['label'])} onChange={(event, newValue: string) => { this.props.onChanged ? this.props.onChanged(newValue) : null }} />
       </div>
     );
   }

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
@@ -118,7 +118,7 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
   }
 
   private wait() {
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
       setTimeout(() => {
         resolve();
         return;
@@ -174,6 +174,10 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
   }
 
   private _onChangedPassword(value: string) {
+    console.log(value);
+  }
+
+  private _onChangedTextWithCallout(value: string) {
     console.log(value);
   }
 
@@ -776,7 +780,8 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                   label: 'Describe your PnP passion with few words',
                   calloutContent: React.createElement('span', {}, 'You can describe your passion with such words as strong, cosmic, all-absorbing, etc.'),
                   calloutWidth: 150,
-                  value: this.properties.textInfoHeaderValue
+                  value: this.properties.textInfoHeaderValue,
+                  onChanged: this._onChangedTextWithCallout
                 }),
                 PropertyFieldToggleWithCallout('toggleInfoHeaderValue', {
                   calloutTrigger: CalloutTriggers.Click,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | NA

#### What's in this Pull Request?

After SPFx 1.12.1 update, looks like something changed in Fabric UI and that causes TextFieldWithCallout to be read-only. This PR fixes that 