### PR TITLE
merge for 2.7.0

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -4,14 +4,19 @@
       "version": "2.7.0",
       "changes": {
         "new": [],
-        "enhancements": [],
+        "enhancements": [
+          "`PropertyFieldColorPicker`: Add debounce property to color picker control [#352](https://github.com/pnp/sp-dev-fx-property-controls/issues/352)"
+        ],
         "fixes": [
           "`PropertyFieldFilePicker`: Stock images url is getting a 404 server error [#364](https://github.com/pnp/sp-dev-fx-property-controls/issues/364)",
-          "`PropertyFieldColumnPicker`: Filter not working properly [#356](https://github.com/pnp/sp-dev-fx-property-controls/issues/356)"
+          "`PropertyFieldColumnPicker`: Filter not working properly [#356](https://github.com/pnp/sp-dev-fx-property-controls/issues/356)",
+          "`PropertyFieldFilePicker`: React crash on large folders [#371](https://github.com/pnp/sp-dev-fx-property-controls/pull/371)"
         ]
       },
       "contributions": [
-        "[Chrisrb05](https://github.com/Chrisrb05)"
+        "[Chrisrb05](https://github.com/Chrisrb05)",
+        "[Konrad K.](https://github.com/wilecoyotegenius)",
+        "[Mark Bice](https://github.com/mbice)"
       ]
     },
     {

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,6 +1,20 @@
 {
   "versions": [
     {
+      "version": "2.7.0",
+      "changes": {
+        "new": [],
+        "enhancements": [],
+        "fixes": [
+          "`PropertyFieldFilePicker`: Stock images url is getting a 404 server error [#364](https://github.com/pnp/sp-dev-fx-property-controls/issues/364)",
+          "`PropertyFieldColumnPicker`: Filter not working properly [#356](https://github.com/pnp/sp-dev-fx-property-controls/issues/356)"
+        ]
+      },
+      "contributions": [
+        "[Chrisrb05](https://github.com/Chrisrb05)"
+      ]
+    },
+    {
       "version": "2.6.0",
       "changes": {
         "new": [],

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -10,7 +10,8 @@
         "fixes": [
           "`PropertyFieldFilePicker`: Stock images url is getting a 404 server error [#364](https://github.com/pnp/sp-dev-fx-property-controls/issues/364)",
           "`PropertyFieldColumnPicker`: Filter not working properly [#356](https://github.com/pnp/sp-dev-fx-property-controls/issues/356)",
-          "`PropertyFieldFilePicker`: React crash on large folders [#371](https://github.com/pnp/sp-dev-fx-property-controls/pull/371)"
+          "`PropertyFieldFilePicker`: React crash on large folders [#371](https://github.com/pnp/sp-dev-fx-property-controls/pull/371)",
+          "`PropertyFieldCollectionData`: PropertyFieldCollectionData is not setting sortIdx on resulting collection when using Add and Save [#369](https://github.com/pnp/sp-dev-fx-property-controls/issues/369)"
         ]
       },
       "contributions": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Releases
 
+## 2.7.0
+
+### Enhancements
+
+- `PropertyFieldColorPicker`: Add debounce property to color picker control [#352](https://github.com/pnp/sp-dev-fx-property-controls/issues/352)
+
+### Fixes
+
+- `PropertyFieldFilePicker`: Stock images url is getting a 404 server error [#364](https://github.com/pnp/sp-dev-fx-property-controls/issues/364)
+- `PropertyFieldColumnPicker`: Filter not working properly [#356](https://github.com/pnp/sp-dev-fx-property-controls/issues/356)
+- `PropertyFieldFilePicker`: React crash on large folders [#371](https://github.com/pnp/sp-dev-fx-property-controls/pull/371)
+- `PropertyFieldCollectionData`: PropertyFieldCollectionData is not setting sortIdx on resulting collection when using Add and Save [#369](https://github.com/pnp/sp-dev-fx-property-controls/issues/369)
+
+### Contributors
+
+Special thanks to our contributors (in alphabetical order): [Chrisrb05](https://github.com/Chrisrb05), [Konrad K.](https://github.com/wilecoyotegenius), [Mark Bice](https://github.com/mbice).
+
 ## 2.6.0
 
 ### Fixes

--- a/docs/documentation/docs/about/release-notes.md
+++ b/docs/documentation/docs/about/release-notes.md
@@ -1,5 +1,22 @@
 # Releases
 
+## 2.7.0
+
+### Enhancements
+
+- `PropertyFieldColorPicker`: Add debounce property to color picker control [#352](https://github.com/pnp/sp-dev-fx-property-controls/issues/352)
+
+### Fixes
+
+- `PropertyFieldFilePicker`: Stock images url is getting a 404 server error [#364](https://github.com/pnp/sp-dev-fx-property-controls/issues/364)
+- `PropertyFieldColumnPicker`: Filter not working properly [#356](https://github.com/pnp/sp-dev-fx-property-controls/issues/356)
+- `PropertyFieldFilePicker`: React crash on large folders [#371](https://github.com/pnp/sp-dev-fx-property-controls/pull/371)
+- `PropertyFieldCollectionData`: PropertyFieldCollectionData is not setting sortIdx on resulting collection when using Add and Save [#369](https://github.com/pnp/sp-dev-fx-property-controls/issues/369)
+
+### Contributors
+
+Special thanks to our contributors (in alphabetical order): [Chrisrb05](https://github.com/Chrisrb05), [Konrad K.](https://github.com/wilecoyotegenius), [Mark Bice](https://github.com/mbice).
+
 ## 2.6.0
 
 ### Fixes

--- a/docs/documentation/docs/controls/PropertyFieldColorPicker.md
+++ b/docs/documentation/docs/controls/PropertyFieldColorPicker.md
@@ -36,6 +36,7 @@ PropertyFieldColorPicker('color', {
   onPropertyChange: this.onPropertyPaneFieldChanged,
   properties: this.properties,
   disabled: false,
+  debounce: 1000,
   isHidden: false,
   alphaSliderHidden: false,
   style: PropertyFieldColorPickerStyle.Full,
@@ -52,6 +53,7 @@ The `PropertyFieldColorPicker` control can be configured with the following prop
 | ---- | ---- | ---- | ---- |
 | label | string | yes | Property field label displayed on top. |
 | disabled | boolean | no | Specify if the control needs to be disabled. |
+| debounce | number | no | Specify delay after which control value will be set. |
 | isHidden | boolean | no | Specify if the control needs to be hidden. |
 | selectedColor | string or IColor | no | The CSS-compatible string or an IColor object to describe the initial color |
 | alphaSliderHidden | boolean | no | When true, the alpha slider control is hidden |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnp/spfx-property-controls",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pnp/spfx-property-controls",
   "description": "Reusable property pane controls for SharePoint Framework solutions",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "engines": {
     "node": ">=0.10.0"
   },

--- a/src/common/telemetry/version.ts
+++ b/src/common/telemetry/version.ts
@@ -1,1 +1,1 @@
-export const version: string = "2.6.0";
+export const version: string = "2.7.0";

--- a/src/propertyFields/collectionData/collectionDataViewer/CollectionDataViewer.tsx
+++ b/src/propertyFields/collectionData/collectionDataViewer/CollectionDataViewer.tsx
@@ -127,7 +127,9 @@ export class CollectionDataViewer extends React.Component<ICollectionDataViewerP
   private addAndSave = () => {
     // Check if the item is not empty
     if (this.state.inCreationItem) {
-      this.props.fOnSave([...this.state.crntItems, this.state.inCreationItem]);
+      let crntItems = [...this.state.crntItems, this.state.inCreationItem];
+      crntItems = this.updateSortProperty(crntItems);
+      this.props.fOnSave(crntItems);
     } else {
       this.onSave();
     }

--- a/src/propertyFields/colorPicker/IPropertyFieldColorPicker.ts
+++ b/src/propertyFields/colorPicker/IPropertyFieldColorPicker.ts
@@ -42,6 +42,11 @@ export interface IPropertyFieldColorPickerProps {
 	disabled?: boolean;
 
 	/**
+	 * Time after which the control is updated
+	 */
+	debounce?: number;
+
+	/**
 	* Whether the property pane field is hidden or not.
 	*/
 	isHidden?: boolean;

--- a/src/propertyFields/colorPicker/IPropertyFieldColorPickerHost.ts
+++ b/src/propertyFields/colorPicker/IPropertyFieldColorPickerHost.ts
@@ -7,6 +7,7 @@ export interface IPropertyFieldColorPickerHostProps {
 	label: string;
 	alphaSliderHidden: boolean;
 	disabled: boolean;
+	debounce: number;
 	isHidden: boolean;
 	selectedColor: string;
 	style: PropertyFieldColorPickerStyle;

--- a/src/propertyFields/columnPicker/PropertyFieldColumnPickerHost.tsx
+++ b/src/propertyFields/columnPicker/PropertyFieldColumnPickerHost.tsx
@@ -66,7 +66,8 @@ export default class PropertyFieldColumnPickerHost extends React.Component<IProp
         this.options = [];
         columnService.getColumns(displayHiddenColumns).then((response: ISPColumns) => {
             // Start mapping the Columns that are selected
-            response.value.forEach((column: ISPColumn) => {
+            const value = response.value || [];
+            value.forEach((column: ISPColumn) => {
                 let colPropsToCheck = columnReturnProperty ? column[columnReturnProperty] : column.Id;
                 if (selectedColumn === colPropsToCheck) {
                     this.selectedKey = columnReturnProperty ? column[columnReturnProperty] : column.Id;

--- a/src/propertyFields/filePicker/filePickerControls/StockImagesTab/StockImages.tsx
+++ b/src/propertyFields/filePicker/filePickerControls/StockImagesTab/StockImages.tsx
@@ -17,7 +17,7 @@ export class StockImages extends React.Component<IStockImagesProps> {
     const { language } = this.props;
 
     const themesColor = `&themecolors=${encodeURIComponent(this.getCurrentThemeConfiguration())}`;
-    const contentPickerUrl = `https://hubblecontent.osi.office.net/contentsvc/external/m365contentpicker/index.html?p=3&app=1001&aud=prod&channel=devmain&setlang=${language}&msel=0&env=prod&premium=1${themesColor}`;
+    const contentPickerUrl = `https://hubblecontent.osi.office.net/contentsvc/m365contentpicker/index.html?p=3&app=1001&aud=prod&channel=devmain&setlang=${language}&msel=0&env=prod&premium=1${themesColor}`;
 
     return (
       <div className={styles.tabContainer}>

--- a/src/propertyFields/filePicker/filePickerControls/controls/FileBrowser/FileBrowser.tsx
+++ b/src/propertyFields/filePicker/filePickerControls/controls/FileBrowser/FileBrowser.tsx
@@ -179,7 +179,7 @@ export class FileBrowser extends React.Component<IFileBrowserProps, IFileBrowser
                         selectionPreservedOnEmptyClick={true}
                         enterModalSelectionOnTouch={true}
                         onRenderRow={this._onRenderRow}
-                        onRenderMissingItem={this._loadNextDataRequest}
+                        onRenderMissingItem={() => { this._loadNextDataRequest(); return null; }}
                       />) :
                       (<TilesList
                         fileBrowserService={this.props.fileBrowserService}

--- a/src/propertyFields/peoplePicker/IPropertyFieldPeoplePicker.ts
+++ b/src/propertyFields/peoplePicker/IPropertyFieldPeoplePicker.ts
@@ -1,4 +1,4 @@
-import { IWebPartContext, IPropertyPaneCustomFieldProps } from '@microsoft/sp-webpart-base';
+import { IWebPartContext } from '@microsoft/sp-webpart-base';
 
 /**
  * PrincipalType controls the type of entities that are returned in the results.

--- a/src/services/SPColumnPickerService.ts
+++ b/src/services/SPColumnPickerService.ts
@@ -53,8 +53,8 @@ export class SPColumnPickerService implements ISPColumnPickerService {
 
                 // Adds an OData Filter to the list
                 if (this.props.filter) {
-                    if (displayHiddenColumns) queryUrl += `&$filter=&${encodeURIComponent(this.props.filter)}`;
-                    else queryUrl += `&$filter=Hidden eq false&${encodeURIComponent(this.props.filter)}`;
+                    if (displayHiddenColumns) queryUrl += `&$filter=${encodeURIComponent(this.props.filter)}`;
+                    else queryUrl += `&$filter=Hidden eq false and ${encodeURIComponent(this.props.filter)}`;
                 } else {
                     if (!displayHiddenColumns) queryUrl += `&$filter=Hidden eq false`;
                 }

--- a/src/services/SPPeopleSearchService.ts
+++ b/src/services/SPPeopleSearchService.ts
@@ -4,7 +4,6 @@ import { PrincipalType, IPropertyFieldGroupOrPerson } from './../propertyFields/
 import { ISPPeopleSearchService } from './ISPPeopleSearchService';
 import SPPeoplePickerMockHttpClient from './SPPeopleSearchMockService';
 import { IWebPartContext } from '@microsoft/sp-webpart-base';
-import { IUsers } from './IUsers';
 
 /**
  * Service implementation to search people in SharePoint

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
@@ -696,6 +696,7 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                   selectedColor: this.properties.color,
                   onPropertyChange: this.onPropertyPaneFieldChanged,
                   properties: this.properties,
+                  debounce: 500,
                   //disabled: true,
                   //alphaSliderHidden: true,
                   //style: PropertyFieldColorPickerStyle.Full,


### PR DESCRIPTION
### Enhancements

- `PropertyFieldColorPicker`: Add debounce property to color picker control [#352](https://github.com/pnp/sp-dev-fx-property-controls/issues/352)

### Fixes

- `PropertyFieldFilePicker`: Stock images url is getting a 404 server error [#364](https://github.com/pnp/sp-dev-fx-property-controls/issues/364)
- `PropertyFieldColumnPicker`: Filter not working properly [#356](https://github.com/pnp/sp-dev-fx-property-controls/issues/356)
- `PropertyFieldFilePicker`: React crash on large folders [#371](https://github.com/pnp/sp-dev-fx-property-controls/pull/371)
- `PropertyFieldCollectionData`: PropertyFieldCollectionData is not setting sortIdx on resulting collection when using Add and Save [#369](https://github.com/pnp/sp-dev-fx-property-controls/issues/369)

### Contributors

Special thanks to our contributors (in alphabetical order): [Chrisrb05](https://github.com/Chrisrb05), [Konrad K.](https://github.com/wilecoyotegenius), [Mark Bice](https://github.com/mbice).