### PR TITLE
401: add onCancel handler for file picker

### DIFF
--- a/docs/documentation/docs/controls/PropertyFieldFilePicker.md
+++ b/docs/documentation/docs/controls/PropertyFieldFilePicker.md
@@ -80,6 +80,7 @@ The `PropertyFieldFilePicker` control can be configured with the following prope
 | buttonIcon | string | no | In case it is provided the file picker will be rendered as an action button. |
 | onSave | (filePickerResult: IFilePickerResult) => void | yes | Handler when the file has been selected and picker has been closed. |
 | onChange | (filePickerResult: IFilePickerResult) => void | no | Handler when the file selection has been changed. |
+| onCancel | () => void | no | Handler when the file picker panel has been closed without selection of a file. |
 | accepts | string[] | no | Array of strings containing allowed files extensions. E.g. [".gif", ".jpg", ".jpeg", ".bmp", ".dib", ".tif", ".tiff", ".ico", ".png", ".jxr", ".svg"] |
 | required | boolean | no | Sets the label to inform that the value is required. |
 | bingAPIKey | string | no | Used to execute WebSearch. If not provided SearchTab will not be available. |

--- a/src/propertyFields/filePicker/IPropertyFieldFilePicker.ts
+++ b/src/propertyFields/filePicker/IPropertyFieldFilePicker.ts
@@ -31,6 +31,11 @@ export interface IPropertyFieldFilePickerProps {
   onChanged?: (filePickerResult: IFilePickerResult) => void;
 
   /**
+   * Handler when the file picker panel has been closed without selection of a file.
+   */
+   onCancel?: () => void;
+
+  /**
    * ClassName to be applied to the opener button element.
    */
   buttonClassName?: string;

--- a/src/propertyFields/filePicker/PropertyFieldFilePicker.ts
+++ b/src/propertyFields/filePicker/PropertyFieldFilePicker.ts
@@ -45,6 +45,7 @@ class PropertyFieldFilePickerBuilder implements IPropertyPaneField<IPropertyFiel
   private buttonIcon?: string;
   private onSave: (filePickerResult: IFilePickerResult) => void;
   private onChanged?: (filePickerResult: IFilePickerResult) => void;
+  private onCancel?: () => void;
   private buttonClassName?: string;
   private panelClassName?: string;
   private accepts?: string[];
@@ -74,6 +75,7 @@ class PropertyFieldFilePickerBuilder implements IPropertyPaneField<IPropertyFiel
 
     this.onSave = _properties.onSave;
     this.onChanged = _properties.onChanged;
+    this.onCancel = _properties.onCancel;
 
     this.itemsCountQueryLimit = _properties.itemsCountQueryLimit !== undefined ? _properties.itemsCountQueryLimit : 100;
 
@@ -113,6 +115,7 @@ class PropertyFieldFilePickerBuilder implements IPropertyPaneField<IPropertyFiel
 
       onSave: this.onSave,
       onChanged: this.onChanged,
+      onCancel: this.onCancel,
       itemsCountQueryLimit: this.itemsCountQueryLimit,
       accepts: this.accepts,
       filePickerResult: this.filePickerResult,

--- a/src/propertyFields/filePicker/PropertyFieldFilePickerHost.tsx
+++ b/src/propertyFields/filePicker/PropertyFieldFilePickerHost.tsx
@@ -39,6 +39,7 @@ export default class PropertyFieldFilePickerHost extends React.Component<IProper
           buttonIcon={this.props.buttonIcon ? this.props.buttonIcon : "FileImage"}
           onSave={(filePickerResult: IFilePickerResult) => { this.handleFileSave(filePickerResult); }}
           onChanged={(filePickerResult: IFilePickerResult) => { this.handleFileChange(filePickerResult); }}
+          onCancel={this.handleCancel}
           context={this.props.context}
           filePickerResult={this.props.filePickerResult}
           buttonClassName={this.props.buttonClassName}
@@ -79,6 +80,12 @@ export default class PropertyFieldFilePickerHost extends React.Component<IProper
 
     if (typeof this.props.onChange !== 'undefined' && this.props.onChange !== null) {
       this.props.onChange(this.props.targetProperty, filePickerResult);
+    }
+  }
+
+  private handleCancel = (): void => {
+    if (this.props.onCancel) {
+      this.props.onCancel();
     }
   }
 

--- a/src/propertyFields/filePicker/filePickerControls/FilePicker.tsx
+++ b/src/propertyFields/filePicker/filePickerControls/FilePicker.tsx
@@ -203,6 +203,7 @@ export class FilePicker extends React.Component<IFilePickerProps, IFilePickerSta
    * Closes the panel
    */
   private _handleClosePanel = () => {
+    this.props.onCancel();
     this.setState({
       panelOpen: false
     });

--- a/src/propertyFields/filePicker/filePickerControls/IFilePickerProps.ts
+++ b/src/propertyFields/filePicker/filePickerControls/IFilePickerProps.ts
@@ -27,6 +27,11 @@ export interface IFilePickerProps {
   onChanged?: (filePickerResult: IFilePickerResult) => void;
 
   /**
+   * Handler when the file picker panel has been closed without selection of a file.
+   */
+  onCancel: () => void;
+
+  /**
    * ClassName to be applied to the opener button element.
    */
   buttonClassName?: string;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | implements #401 

#### What's in this Pull Request?

Adds optional `onCancel` handler to File Picker component.

