### PR TITLE
Added a feature to allow external links / Added a feature to show the Site Pages in the Site tab

### DIFF
--- a/src/loc/bg-bg.js
+++ b/src/loc/bg-bg.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "Само за творческата общност",
   "LicensePlaceholderText": "Лиценз",
   "LinkFileInstructions": "Поставяне на връзка към файл в OneDrive за бизнес или SharePoint Online",
+  "ExternalLinkFileInstructions": "Поставете връзка към сайт, страница, документ, списък, библиотека (https:// или http://)",
   "LinkHeader": "От връзка",
   "LinkImageInstructions": "Поставяне на връзка към изображение в OneDrive за бизнес или SharePoint Online",
   "ListLayoutAriaLabel": "Преглед на опциите. {0} {1} .",

--- a/src/loc/ca-es.js
+++ b/src/loc/ca-es.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "Només Creative Commons",
   "LicensePlaceholderText": "Llicència",
   "LinkFileInstructions": "Enganxar un enllaç a un fitxer del OneDrive for Business o del SharePoint Online",
+  "ExternalLinkFileInstructions": "Enganxeu un enllaç a un lloc, pàgina, document, llista, biblioteca (https:// o http://)",
   "LinkHeader": "Des d'un enllaç",
   "LinkImageInstructions": "Enganxar un enllaç a una imatge del OneDrive for Business o del SharePoint Online",
   "ListLayoutAriaLabel": "Visualitza les opcions. {0} {1} .",

--- a/src/loc/da-dk.js
+++ b/src/loc/da-dk.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "Kun Creative Commons",
   "LicensePlaceholderText": "Licens",
   "LinkFileInstructions": "Indsætte et link til en fil i OneDrive for Business eller SharePoint Online",
+  "ExternalLinkFileInstructions": "Indsæt et link til et websted, en side, et dokument, en liste, et bibliotek (https:// eller http://)",
   "LinkHeader": "Fra et link",
   "LinkImageInstructions": "Indsætte et link til et billede i OneDrive for Business eller SharePoint Online",
   "ListLayoutAriaLabel": "Få vist indstillinger. {0} {1} .",

--- a/src/loc/de-de.js
+++ b/src/loc/de-de.js
@@ -124,6 +124,7 @@ define([], () => {
   "LicenseOptionAny": "Nur Creative Commons",
   "LicensePlaceholderText": "Lizenz",
   "LinkFileInstructions": "Einfügen eines Links zu einer Datei in OneDrive for Business oder SharePoint Online",
+  "ExternalLinkFileInstructions": "Fügen Sie einen Link zu einer Site, Seite, einem Dokument, einer Liste oder einer Bibliothek ein (https:// oder http://)",
   "LinkHeader": "Von einem Link",
   "LinkImageInstructions": "Einfügen eines Links zu einem Bild in OneDrive for Business oder SharePoint Online",
   "ListLayoutAriaLabel": "Optionen anzeigen. {0} {1} .",

--- a/src/loc/el-gr.js
+++ b/src/loc/el-gr.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "Μόνο δημιουργικά κοινά",
   "LicensePlaceholderText": "Άδεια",
   "LinkFileInstructions": "Επικόλληση σύνδεσης σε αρχείο στο OneDrive για επιχειρήσεις ή στο SharePoint Online",
+  "ExternalLinkFileInstructions": "Επικολλήστε έναν σύνδεσμο προς έναν ιστότοπο, σελίδα, έγγραφο, λίστα, βιβλιοθήκη (https:// ή http://)",
   "LinkHeader": "Από μια σύνδεση",
   "LinkImageInstructions": "Επικόλληση σύνδεσης σε εικόνα στο OneDrive για επιχειρήσεις ή στο SharePoint Online",
   "ListLayoutAriaLabel": "Προβολή επιλογών. {0} {1} .",

--- a/src/loc/en-us.js
+++ b/src/loc/en-us.js
@@ -125,6 +125,7 @@ define([], function () {
     LicenseOptionAny: "Creative Commons only",
     LicensePlaceholderText: "License",
     LinkFileInstructions: "Paste a link to a file in OneDrive for Business or SharePoint Online",
+    ExternalLinkFileInstructions: "Paste a link to a site, page, document, list, library (https:// or http://)",
     LinkHeader: "From a link",
     LinkImageInstructions: "Paste a link to an image in OneDrive for Business or SharePoint Online",
     ListLayoutAriaLabel: "View options. {0}  {1} .",

--- a/src/loc/es-es.js
+++ b/src/loc/es-es.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "Creative Commons solamente",
   "LicensePlaceholderText": "Licencia",
   "LinkFileInstructions": "Pegue un vínculo a un archivo en OneDrive para la Empresa o SharePoint Online",
+  "ExternalLinkFileInstructions": "Pegue un enlace a un sitio, página, documento, lista, biblioteca (https: // o http: //)",
   "LinkHeader": "Desde un enlace",
   "LinkImageInstructions": "Pegue un vínculo a una imagen en OneDrive para la Empresa o SharePoint Online",
   "ListLayoutAriaLabel": "Ver opciones. {0} {1} .",

--- a/src/loc/et-ee.js
+++ b/src/loc/et-ee.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "Ainult creative commons",
   "LicensePlaceholderText": "Litsentsi",
   "LinkFileInstructions": "Faili lingi kleepimine oneDrive for Businessis või SharePoint Online'is",
+  "ExternalLinkFileInstructions": "Kleepige link saidile, lehele, dokumendile, loendile, teegile (https:// või http://)",
   "LinkHeader": "Lingilt",
   "LinkImageInstructions": "Pildi lingi kleepimine OneDrive for Businessis või SharePoint Online'is",
   "ListLayoutAriaLabel": "Saate vaadata valikuid. {0} {1} .",

--- a/src/loc/fi-fi.js
+++ b/src/loc/fi-fi.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "Creative Commons vain",
   "LicensePlaceholderText": "Lisenssi",
   "LinkFileInstructions": "Linkin liittäminen tiedostoon OneDrive for Businessissa tai SharePoint Onlinessa",
+  "ExternalLinkFileInstructions": "Liitä linkki sivustoon, sivuun, asiakirjaan, luetteloon, kirjastoon (https:// tai http://)",
   "LinkHeader": "Linkistä",
   "LinkImageInstructions": "Linkin liittäminen kuvaan OneDrive for Businessissa tai SharePoint Onlinessa",
   "ListLayoutAriaLabel": "Näytä asetukset. {0} {1} .",

--- a/src/loc/fr-fr.js
+++ b/src/loc/fr-fr.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "Creative Commons uniquement",
   "LicensePlaceholderText": "Licence",
   "LinkFileInstructions": "Coller un lien vers un fichier dans OneDrive Entreprise ou SharePoint Online",
+  "ExternalLinkFileInstructions": "Coller un lien vers un site, une page, un document, une liste, une bibliothèque (https:// ou http://)",
   "LinkHeader": "À partir d’un lien",
   "LinkImageInstructions": "Coller un lien vers une image dans OneDrive Entreprise ou SharePoint Online",
   "ListLayoutAriaLabel": "Afficher les options. {0} {1} .",

--- a/src/loc/it-it.js
+++ b/src/loc/it-it.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "Solo Creative Commons",
   "LicensePlaceholderText": "Licenza",
   "LinkFileInstructions": "Incollare un collegamento a un file in OneDrive for Business o SharePoint Online",
+  "ExternalLinkFileInstructions": "Incollare un collegamento a un sito, una pagina, un documento, un elenco, una raccolta (https:// o http://)",
   "LinkHeader": "Da un link",
   "LinkImageInstructions": "Incollare un collegamento a un'immagine in OneDrive for Business o SharePoint Online",
   "ListLayoutAriaLabel": "Opzioni di visualizzazione. {0} {1} .",

--- a/src/loc/ja-jp.js
+++ b/src/loc/ja-jp.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "クリエイティブ・コモンズのみ",
   "LicensePlaceholderText": "ライセンス",
   "LinkFileInstructions": "ビジネスまたは SharePoint オンラインの OneDrive のファイルへのリンクを貼り付ける",
+  "ExternalLinkFileInstructions": "サイト、ページ、ドキュメント、リスト、ライブラリへのリンクを貼り付けます（https：//またはhttp：//）",
   "LinkHeader": "リンクから",
   "LinkImageInstructions": "ビジネスまたは SharePoint オンラインの OneDrive のイメージへのリンクを貼り付ける",
   "ListLayoutAriaLabel": "オプションを表示します。{0} {1} .",

--- a/src/loc/lt-lt.js
+++ b/src/loc/lt-lt.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "Tik kūrybinės commons",
   "LicensePlaceholderText": "Licencijos",
   "LinkFileInstructions": "Saito į failą įklijavimas \"OneDrive\" verslui arba \"SharePoint Online\"",
+  "ExternalLinkFileInstructions": "Įklijuokite nuorodą į svetainę, puslapį, dokumentą, sąrašą, biblioteką (https:// arba http://)",
   "LinkHeader": "Iš nuorodos",
   "LinkImageInstructions": "Saito į vaizdą įklijavimas \"OneDrive\" verslui arba \"SharePoint Online\"",
   "ListLayoutAriaLabel": "Peržiūrėti parinktis. {0} {1} .",

--- a/src/loc/lv-lv.js
+++ b/src/loc/lv-lv.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "Tikai Creative Commons",
   "LicensePlaceholderText": "Licences",
   "LinkFileInstructions": "Saites uz failu ielīmēšana pakalpojumā OneDrive darbam vai SharePoint Online",
+  "ExternalLinkFileInstructions": "Ielīmējiet saiti uz vietni, lapu, dokumentu, sarakstu, bibliotēku (https:// vai http://)",
   "LinkHeader": "No saites",
   "LinkImageInstructions": "Saites ielīmēšana uz attēlu pakalpojumā OneDrive darbam vai SharePoint Online",
   "ListLayoutAriaLabel": "Skatīt opcijas. {0} {1} .",

--- a/src/loc/mystrings.d.ts
+++ b/src/loc/mystrings.d.ts
@@ -149,6 +149,7 @@ declare interface IPropertyControlStrings {
   LicenseOptionAny: string;
   LicensePlaceholderText: string;
   LinkFileInstructions: string;
+  ExternalLinkFileInstructions: string;
   LinkHeader: string;
   LinkImageInstructions: string;
   ListLayoutAriaLabel: string;

--- a/src/loc/nb-no.js
+++ b/src/loc/nb-no.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "Kun Creative Commons",
   "LicensePlaceholderText": "Lisens",
   "LinkFileInstructions": "Lime inn en kobling til en fil i OneDrive for Business eller SharePoint Online",
+  "ExternalLinkFileInstructions": "Lim inn en kobling til et nettsted, side, dokument, liste, bibliotek (https:// eller http://)",
   "LinkHeader": "Fra en kobling",
   "LinkImageInstructions": "Lime inn en kobling til et bilde i OneDrive for Business eller SharePoint Online",
   "ListLayoutAriaLabel": "Vis alternativer. {0} {1} .",

--- a/src/loc/nl-nl.js
+++ b/src/loc/nl-nl.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "Alleen Creative Commons",
   "LicensePlaceholderText": "Licentie",
   "LinkFileInstructions": "Een koppeling naar een bestand plakken in OneDrive voor Bedrijven of SharePoint Online",
+  "ExternalLinkFileInstructions": "Plak een link naar een site, pagina, document, lijst, bibliotheek (https:// of http://)",
   "LinkHeader": "Van een link",
   "LinkImageInstructions": "Een koppeling naar een afbeelding plakken in OneDrive voor Bedrijven of SharePoint Online",
   "ListLayoutAriaLabel": "Opties weergeven. {0} {1} .",

--- a/src/loc/no.js
+++ b/src/loc/no.js
@@ -77,6 +77,7 @@ define([], function() {
     DescriptionLabel: "Beskrivelse",
     MoreInfoLabel: "Mer informasjon",
     AboutGroupLabel: "Om",
+    ExternalLinkFileInstructions: "Lim inn en kobling til et nettsted, side, dokument, liste, bibliotek (https:// eller http://)",
 
   }
 });

--- a/src/loc/pl-pl.js
+++ b/src/loc/pl-pl.js
@@ -124,6 +124,7 @@ define([], () => {
   "LicenseOptionAny": "Tylko Creative Commons",
   "LicensePlaceholderText": "Licencji",
   "LinkFileInstructions": "Wklejanie łącza do pliku w usłudze OneDrive dla Firm lub usłudze SharePoint Online",
+  "ExternalLinkFileInstructions": "Wklej link do witryny, strony, dokumentu, listy, biblioteki (https:// lub http://)",
   "LinkHeader": "Z linku",
   "LinkImageInstructions": "Wklejanie łącza do obrazu w usłudze OneDrive dla Firm lub usłudze SharePoint Online",
   "ListLayoutAriaLabel": "Opcje wyświetlania. {0} {1} .",

--- a/src/loc/pt-pt.js
+++ b/src/loc/pt-pt.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "Apenas Comuns Criativos",
   "LicensePlaceholderText": "Licença",
   "LinkFileInstructions": "Cole um link para um ficheiro no OneDrive para Negócios ou SharePoint Online",
+  "ExternalLinkFileInstructions": "Cole um link para um site, página, documento, lista, biblioteca (https: // ou http: //)",
   "LinkHeader": "De um link",
   "LinkImageInstructions": "Cole um link para uma imagem no OneDrive para Business ou SharePoint Online",
   "ListLayoutAriaLabel": "Ver opções. {0} {1} .",

--- a/src/loc/ro-ro.js
+++ b/src/loc/ro-ro.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "Numai Creative Commons",
   "LicensePlaceholderText": "Licenţă",
   "LinkFileInstructions": "Lipirea unui link la un fișier în OneDrive pentru business sau SharePoint Online",
+  "ExternalLinkFileInstructions": "Lipiți un link către un site, pagină, document, listă, bibliotecă (https:// sau http://)",
   "LinkHeader": "Dintr-un link",
   "LinkImageInstructions": "Lipirea unui link la o imagine în OneDrive pentru business sau SharePoint Online",
   "ListLayoutAriaLabel": "Vizualizați opțiunile. {0} {1} .",

--- a/src/loc/ru-ru.js
+++ b/src/loc/ru-ru.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "Creative Commons только",
   "LicensePlaceholderText": "Лицензии",
   "LinkFileInstructions": "Вставьте ссылку на файл в OneDrive для бизнеса или SharePoint Online",
+  "ExternalLinkFileInstructions": "Вставьте ссылку на сайт, страницу, документ, список, библиотеку (https: // или http: //)",
   "LinkHeader": "По ссылке",
   "LinkImageInstructions": "Вставьте ссылку на изображение в OneDrive для бизнеса или SharePoint Online",
   "ListLayoutAriaLabel": "Просмотр опций. {0} {1} .",

--- a/src/loc/sk-sk.js
+++ b/src/loc/sk-sk.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "Iba Creative Commons",
   "LicensePlaceholderText": "Licencie",
   "LinkFileInstructions": "Prilepiť prepojenie na súbor vo OneDrive for Business alebo SharePointe Online",
+  "ExternalLinkFileInstructions": "Prilepte odkaz na lokalitu, stránku, dokument, zoznam, knižnicu (https:// alebo http://)",
   "LinkHeader": "Z prepojenia",
   "LinkImageInstructions": "Prilepiť prepojenie na obrázok vo OneDrive for Business alebo SharePointe Online",
   "ListLayoutAriaLabel": "Zobraziť možnosti. {0} {1} .",

--- a/src/loc/sr-latn-rs.js
+++ b/src/loc/sr-latn-rs.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "Samo kreativni commons",
   "LicensePlaceholderText": "Dozvolu",
   "LinkFileInstructions": "Lepljenje veze ka datoteci u usluzi OneDrive for Business ili SharePoint Online",
+  "ExternalLinkFileInstructions": "Pegar un enlace a un sitio, página, documento, lista, biblioteca (https:// o http://)",
   "LinkHeader": "Iz veze",
   "LinkImageInstructions": "Lepljenje veze ka slici u usluzi OneDrive for Business ili SharePoint Online",
   "ListLayoutAriaLabel": "Prikažite opcije. {0} {1} .",

--- a/src/loc/sv-se.js
+++ b/src/loc/sv-se.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "Endast Creative Commons",
   "LicensePlaceholderText": "Licens",
   "LinkFileInstructions": "Klistra in en länk till en fil i OneDrive för företag eller SharePoint Online",
+  "ExternalLinkFileInstructions": "Klistra in en länk till en webbplats, sida, dokument, lista, bibliotek (https:// eller http://)",
   "LinkHeader": "Från en länk",
   "LinkImageInstructions": "Klistra in en länk till en bild i OneDrive för företag eller SharePoint Online",
   "ListLayoutAriaLabel": "Visa alternativ. {0} {1} .",

--- a/src/loc/tr-tr.js
+++ b/src/loc/tr-tr.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "Yalnızca Creative Commons",
   "LicensePlaceholderText": "Lisans",
   "LinkFileInstructions": "OneDrive for Business veya SharePoint Online'da bir dosyaya bağlantı yapıştır",
+  "ExternalLinkFileInstructions": "Bir siteye, sayfaya, belgeye, listeye, kitaplığa bağlantı yapıştırın (https:// veya http://)",
   "LinkHeader": "Bir bağlantıdan",
   "LinkImageInstructions": "OneDrive for Business veya SharePoint Online'daki bir resme bağlantı yapıştır",
   "ListLayoutAriaLabel": "Seçenekleri görüntüleyin. {0} {1} .",

--- a/src/loc/vi-vn.js
+++ b/src/loc/vi-vn.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "Chỉ Creative Commons",
   "LicensePlaceholderText": "Giấy phép",
   "LinkFileInstructions": "Dán nối kết đến tệp trong OneDrive for Business hoặc SharePoint Online",
+  "ExternalLinkFileInstructions": "Dán liên kết đến một trang, trang, tài liệu, danh sách, thư viện (https: // hoặc http: //)",
   "LinkHeader": "Từ một liên kết",
   "LinkImageInstructions": "Dán nối kết đến ảnh trong OneDrive for Business hoặc SharePoint Online",
   "ListLayoutAriaLabel": "Xem tùy chọn. {0} {1} .",

--- a/src/loc/zh-cn.js
+++ b/src/loc/zh-cn.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "仅知识共享",
   "LicensePlaceholderText": "许可证",
   "LinkFileInstructions": "将指向\"企业\"或\"共享点联机\"中的文件的链接粘贴",
+  "ExternalLinkFileInstructions": "将链接粘贴到站点、页面、文档、列表、库（https:// 或 http://）",
   "LinkHeader": "从链接",
   "LinkImageInstructions": "在 OneDrive 中粘贴指向图像的链接，用于业务或共享点联机",
   "ListLayoutAriaLabel": "查看选项。{0} {1} .",

--- a/src/loc/zh-tw.js
+++ b/src/loc/zh-tw.js
@@ -123,6 +123,7 @@ define([], () => {
   "LicenseOptionAny": "僅知識共用。",
   "LicensePlaceholderText": "許可證。",
   "LinkFileInstructions": "將指向「企業」或「共用點連線」中的檔的連結粘貼。",
+  "ExternalLinkFileInstructions": "將鏈接粘貼到站點、頁面、文檔、列表、庫（https:// 或 http://）",
   "LinkHeader": "從連結。",
   "LinkImageInstructions": "在 OneDrive 中貼貼指向圖像的連結,用於業務或共用點連線。",
   "ListLayoutAriaLabel": "查看選項。{0} {1} .",

--- a/src/propertyFields/filePicker/IPropertyFieldFilePicker.ts
+++ b/src/propertyFields/filePicker/IPropertyFieldFilePicker.ts
@@ -145,6 +145,19 @@ export interface IPropertyFieldFilePickerProps {
    * Specifies if StockImagesTab should be hidden.
    */
   hideStockImages?: boolean;
+
+  /**
+   * Specifies if external links are allowed
+   */
+   allowExternalTenantLinks?: boolean;
+  /**
+   * Specifies if file check should be done
+   */
+   checkIfFileExists?: boolean;
+  /**
+   * Specifies if Site Pages is displayed in the Site Tab
+   */
+   displaySitePages?: boolean;
 }
 
 export interface IPropertyFieldFilePickerPropsInternal extends IPropertyFieldFilePickerProps {

--- a/src/propertyFields/filePicker/PropertyFieldFilePicker.ts
+++ b/src/propertyFields/filePicker/PropertyFieldFilePicker.ts
@@ -34,6 +34,10 @@ class PropertyFieldFilePickerBuilder implements IPropertyPaneField<IPropertyFiel
   private hideOneDriveTab: boolean;
   private hideStockImages: boolean;
 
+  private allowExternalTenantLinks: boolean;
+  private checkIfFileExists: boolean;
+  private displaySitePages: boolean;
+
   private customProperties: any;
   private key: string;
   private disabled: boolean = false;
@@ -90,6 +94,10 @@ class PropertyFieldFilePickerBuilder implements IPropertyPaneField<IPropertyFiel
     this.storeLastActiveTab = _properties.storeLastActiveTab !== undefined ? _properties.storeLastActiveTab : true;
     this.defaultSelectedTab = _properties.defaultSelectedTab;
     this.hideStockImages = _properties.hideStockImages !== undefined ? _properties.hideStockImages : false;
+    this.allowExternalTenantLinks = _properties.allowExternalTenantLinks !== undefined ? _properties.allowExternalTenantLinks : true;
+    this.checkIfFileExists = _properties.checkIfFileExists !== undefined ? _properties.checkIfFileExists : true;
+    this.displaySitePages = _properties.displaySitePages !== undefined ? _properties.displaySitePages : false;
+
     this.onPropertyChange = _properties.onPropertyChange;
     this.customProperties = _properties.properties;
     this.key = _properties.key;
@@ -133,6 +141,10 @@ class PropertyFieldFilePickerBuilder implements IPropertyPaneField<IPropertyFiel
       defaultSelectedTab: this.defaultSelectedTab,
       hideStockImages: this.hideStockImages,
       targetProperty: this.targetProperty,
+
+      allowExternalTenantLinks: this.allowExternalTenantLinks,
+      checkIfFileExists: this.checkIfFileExists,
+      displaySitePages: this.displaySitePages,
 
       properties: this.customProperties,
       key: this.key,

--- a/src/propertyFields/filePicker/PropertyFieldFilePickerHost.tsx
+++ b/src/propertyFields/filePicker/PropertyFieldFilePickerHost.tsx
@@ -58,6 +58,9 @@ export default class PropertyFieldFilePickerHost extends React.Component<IProper
           panelClassName={this.props.panelClassName}
           storeLastActiveTab={this.props.storeLastActiveTab}
           defaultSelectedTab={this.props.defaultSelectedTab}
+          allowExternalTenantLinks={this.props.allowExternalTenantLinks}
+          checkIfFileExists={this.props.checkIfFileExists}
+          displaySitePages={this.props.displaySitePages}
         />
       </div>
     );

--- a/src/propertyFields/filePicker/filePickerControls/FilePicker.tsx
+++ b/src/propertyFields/filePicker/filePickerControls/FilePicker.tsx
@@ -117,7 +117,8 @@ export class FilePicker extends React.Component<IFilePickerProps, IFilePickerSta
               this.state.selectedTab === FilePickerTabType.LinkUploadTab &&
               <LinkFilePickerTab
                 fileSearchService={this.fileSearchService}
-                allowExternalTenantLinks={true}
+                allowExternalTenantLinks={this.props.allowExternalTenantLinks}
+                checkIfFileExists={this.props.checkIfFileExists}
                 {...linkTabProps}
               />
             }
@@ -139,6 +140,7 @@ export class FilePicker extends React.Component<IFilePickerProps, IFilePickerSta
               this.state.selectedTab === FilePickerTabType.SiteFilesTab &&
               <SiteFilePickerTab
                 fileBrowserService={this.fileBrowserService}
+                displaySitePages={this.props.displaySitePages}
                 {...linkTabProps}
               />
             }

--- a/src/propertyFields/filePicker/filePickerControls/IFilePickerProps.ts
+++ b/src/propertyFields/filePicker/filePickerControls/IFilePickerProps.ts
@@ -121,4 +121,17 @@ export interface IFilePickerProps {
    * Specifies if StockImagesTab should be hidden.
    */
   hideStockImages?: boolean;
+
+  /**
+   * Specifies if external links are allowed
+   */
+  allowExternalTenantLinks?: boolean;
+  /**
+   * Specifies if file check should be done
+   */
+   checkIfFileExists?: boolean;
+  /**
+   * Specifies if Site Pages is displayed in the Site Tab
+   */
+   displaySitePages?: boolean;
 }

--- a/src/propertyFields/filePicker/filePickerControls/LinkFilePickerTab/ILinkFilePickerTabProps.ts
+++ b/src/propertyFields/filePicker/filePickerControls/LinkFilePickerTab/ILinkFilePickerTabProps.ts
@@ -4,4 +4,5 @@ import { FilesSearchService } from "../../../../services/FilesSearchService";
 export interface ILinkFilePickerTabProps extends IFilePickerTab {
   allowExternalTenantLinks: boolean;
   fileSearchService: FilesSearchService;
+  checkIfFileExists: boolean;
 }

--- a/src/propertyFields/filePicker/filePickerControls/LinkFilePickerTab/LinkFilePickerTab.tsx
+++ b/src/propertyFields/filePicker/filePickerControls/LinkFilePickerTab/LinkFilePickerTab.tsx
@@ -31,8 +31,8 @@ export default class LinkFilePickerTab extends React.Component<ILinkFilePickerTa
             resizable={false}
             deferredValidationTime={300}
             className={styles.linkTextField}
-            label={strings.LinkFileInstructions}
-            ariaLabel={strings.LinkFileInstructions}
+            label={this.props.allowExternalTenantLinks ? strings.ExternalLinkFileInstructions : strings.LinkFileInstructions}
+            ariaLabel={this.props.allowExternalTenantLinks ? strings.ExternalLinkFileInstructions : strings.LinkFileInstructions}
             defaultValue={"https://"}
             onGetErrorMessage={(value: string) => this._getErrorMessagePromise(value)}
             autoAdjustHeight={false}
@@ -94,6 +94,11 @@ export default class LinkFilePickerTab extends React.Component<ILinkFilePickerTa
     if (!this.props.allowExternalTenantLinks && !this._isSameDomain(value)) {
       this.setState({ isValid: false });
       return strings.NoExternalLinksValidationMessage;
+    }
+
+    if(!this.props.checkIfFileExists){
+      this.setState({ isValid: true });
+      return '';
     }
 
     const fileExists = await this.props.fileSearchService.checkFileExists(value);

--- a/src/propertyFields/filePicker/filePickerControls/SiteFilePickerTab/ISiteFilePickerTabProps.ts
+++ b/src/propertyFields/filePicker/filePickerControls/SiteFilePickerTab/ISiteFilePickerTabProps.ts
@@ -4,6 +4,7 @@ import { IBreadcrumbItem } from "office-ui-fabric-react/lib/Breadcrumb";
 
 export interface ISiteFilePickerTabProps extends IFilePickerTab {
   fileBrowserService: FileBrowserService;
+  displaySitePages?: boolean;
 
   /**
    * Represents the base node in the breadrumb navigation

--- a/src/propertyFields/filePicker/filePickerControls/SiteFilePickerTab/SiteFilePickerTab.tsx
+++ b/src/propertyFields/filePicker/filePickerControls/SiteFilePickerTab/SiteFilePickerTab.tsx
@@ -44,7 +44,8 @@ export default class SiteFilePickerTab extends React.Component<ISiteFilePickerTa
           {this.state.libraryAbsolutePath === undefined &&
             <DocumentLibraryBrowser
               fileBrowserService={this.props.fileBrowserService}
-              onOpenLibrary={(selectedLibrary: ILibrary) => this._handleOpenLibrary(selectedLibrary, true)} />}
+              onOpenLibrary={(selectedLibrary: ILibrary) => this._handleOpenLibrary(selectedLibrary, true)} 
+              displaySitePages={this.props.displaySitePages}/>}
           {this.state.libraryAbsolutePath !== undefined &&
             <FileBrowser
               onChange={(filePickerResult: IFilePickerResult) => this._handleSelectionChange(filePickerResult)}

--- a/src/propertyFields/filePicker/filePickerControls/controls/DocumentLibraryBrowser/DocumentLibraryBrowser.tsx
+++ b/src/propertyFields/filePicker/filePickerControls/controls/DocumentLibraryBrowser/DocumentLibraryBrowser.tsx
@@ -40,7 +40,8 @@ export class DocumentLibraryBrowser extends React.Component<IDocumentLibraryBrow
   }
 
   public async componentDidMount() {
-    const lists = await this.props.fileBrowserService.getSiteMediaLibraries();
+    let includePageLibraries = this.props.displaySitePages ? this.props.displaySitePages : false;
+    const lists = await this.props.fileBrowserService.getSiteMediaLibraries(includePageLibraries);
     this.setState({
       lists: lists,
       isLoading: false

--- a/src/propertyFields/filePicker/filePickerControls/controls/DocumentLibraryBrowser/IDocumentLibraryBrowserProps.ts
+++ b/src/propertyFields/filePicker/filePickerControls/controls/DocumentLibraryBrowser/IDocumentLibraryBrowserProps.ts
@@ -3,5 +3,6 @@ import { ILibrary } from "../../../../../services/FileBrowserService.types";
 
 export interface IDocumentLibraryBrowserProps {
   fileBrowserService: FileBrowserService;
+  displaySitePages?: boolean;
   onOpenLibrary: (selectedLibrary: ILibrary) => void;
 }


### PR DESCRIPTION
… Site Pages in the Site tab

#### Category
- [ ] Bug fix
- [x] New feature
- [ ] New Sample
- [ ] Related issues

#### What's in this Pull Request?

I added three new properties for the PropertyFieldFilePicker: allowExternalTenantLinks, checkIfFileExists and displaySitePages. 

##### allowExternalTenantLinks

This property allows the user to use external links such as https://www.google.com/ when it is set to true. This is set to be the default value.
![External link allowed](https://user-images.githubusercontent.com/32335472/149752824-73459a16-f6da-4c83-acdf-5d7843d25ec7.PNG)
If it is set to false the user can only use SharePoint links which is the  original behaviour.
![External links not allowed](https://user-images.githubusercontent.com/32335472/149753153-9c0d1887-d479-4fb2-9dfc-d39c6cdeb08e.PNG)

##### checkIfFileExists 

When using file links, this property allows the user to choose if the control should check if the link point to a file that exists or not. 
Here checkIfFileExists property is set to true, thus the check is done. As the file link is valid, we do not get an error message. 
![file exists](https://user-images.githubusercontent.com/32335472/149753824-12b7137e-5fdb-4e49-bebd-a50a11063bef.PNG)
If we make the link invalid (removing the last character of the link), we get an error.
![File does not exist](https://user-images.githubusercontent.com/32335472/149754233-3e0f8954-eb38-4ee9-b9e6-acb45ffb5108.PNG)


Here checkIfFileExists property is set to false, and the link is invalid, the user can still use the link.

![File does not exist and checkifFileExists is false](https://user-images.githubusercontent.com/32335472/149754440-6460e1c3-489d-4055-8dee-35d3fde21f52.PNG)


##### displaySitePages

In the Site tab, the original behaviour only shows the Documents and the Site Assets folders.
![Without Site Pages](https://user-images.githubusercontent.com/32335472/149754685-505926d5-df17-40cc-8692-d7620721c46d.PNG)
The displaySitePages property allows the user to display the Site Pages folder too if set to true.
![Site Pages displayed](https://user-images.githubusercontent.com/32335472/149754849-d714436b-097c-4583-84a4-2080dcb37af1.PNG)

