### PR TITLE
Corrects issue in collection data where valid line disables add button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3300,16 +3300,6 @@
         "msal": "1.4.13",
         "msalLegacy": "npm:msal@1.4.12",
         "tslib": "~1.10.0"
-      },
-      "dependencies": {
-        "msalLegacy": {
-          "version": "npm:msal@1.4.12",
-          "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.12.tgz",
-          "integrity": "sha512-gjupwQ6nvNL6mZkl5NIXyUmZhTiEMRu5giNdgHMh8l5EPOnV2Xj6nukY1NIxFacSTkEYUSDB47Pej9GxDYf+1w==",
-          "requires": {
-            "tslib": "^1.9.3"
-          }
-        }
       }
     },
     "@microsoft/sp-loader": {
@@ -16985,6 +16975,14 @@
       "version": "1.4.13",
       "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.13.tgz",
       "integrity": "sha512-uFEa4KGlpGqNMwa7/1OQc6WQUF8iwHbaiHMVn0Cl66Ec7o30ZTtX9s9OWrf0wAxp8Mwg0JEE886z/PHpsiZUxQ==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "msalLegacy": {
+      "version": "npm:msal@1.4.12",
+      "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.12.tgz",
+      "integrity": "sha512-gjupwQ6nvNL6mZkl5NIXyUmZhTiEMRu5giNdgHMh8l5EPOnV2Xj6nukY1NIxFacSTkEYUSDB47Pej9GxDYf+1w==",
       "requires": {
         "tslib": "^1.9.3"
       }

--- a/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
+++ b/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
@@ -73,10 +73,10 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
     // Check if current item is valid
     if (this.props.fAddInCreation) {
       if (await this.checkRowIsValidForSave(crntItem)) {
-        disableAdd = true;
+        disableAdd = false;
         this.props.fAddInCreation(crntItem, true);
       } else {
-        disableAdd = false;
+        disableAdd = true;
         this.props.fAddInCreation(crntItem, false);
       }
     }


### PR DESCRIPTION


| Q               | A
| --------------- | ---
| Bug fix?        | [x ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?
A single commit that corrects an issue described below.

This PR addresses an issue where a valid line causes the add button to be disabled instead of enabled. See issue #436 for information on the issue. The fix now disables the add button when required fields have not been met and enables once the row is valid.
<img width="890" alt="fix_1" src="https://user-images.githubusercontent.com/42096464/156582006-3ced80bb-998e-42c0-82dd-802234927641.png">
<img width="908" alt="fix_2" src="https://user-images.githubusercontent.com/42096464/156582018-52b6b4a3-e580-4fe1-841c-b7b6a5c9f02d.png">

