### PR TITLE
[Bug fix] Site Picker search for any input string

### DIFF
--- a/src/propertyFields/listPicker/IPropertyFieldListPickerHost.ts
+++ b/src/propertyFields/listPicker/IPropertyFieldListPickerHost.ts
@@ -45,5 +45,5 @@ export interface ISPList {
   RootFolder: {
     ServerRelativeUrl: string;
   };
-  ContentTypes: Array<ISPContentType>
+  ContentTypes: Array<ISPContentType>;
 }

--- a/src/propertyFields/sitePicker/PropertyFieldSitePickerHost.tsx
+++ b/src/propertyFields/sitePicker/PropertyFieldSitePickerHost.tsx
@@ -38,23 +38,23 @@ export default class PropertyFieldSitePickerHost extends React.Component<IProper
   }
 
   private onSearchFieldChange = async (newValue?: string): Promise<void> => {
-    if (newValue && newValue.length > 2) {
-      this.setState({ isLoading: true });
-      try {
-        const {
-          context,
-          trimDuplicates,
-          additionalQuery
-        } = this.props;
-        const sites = await this.searchService.searchSites(this.props.context, newValue, !!trimDuplicates, additionalQuery);
-        this.setState({ siteSearchResults: sites });
-      } catch (error) {
-        this.setState({ errorMessage: error });
-      } finally {
-        this.setState({ isLoading: false });
-      }
-    } else {
+    if (!newValue) {
       this.setState({ siteSearchResults: [] });
+      return;
+    }
+
+    this.setState({ isLoading: true });
+    try {
+      const {
+        trimDuplicates,
+        additionalQuery
+      } = this.props;
+      const sites = await this.searchService.searchSites(this.props.context, newValue, !!trimDuplicates, additionalQuery);
+      this.setState({ siteSearchResults: sites });
+    } catch (error) {
+      this.setState({ errorMessage: error });
+    } finally {
+      this.setState({ isLoading: false });
     }
   }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #386

#### What's in this Pull Request?

* Added missing semicolon
* Updated Site Picker component to search on any input string. Previously the site picker only searched when 3 chars were entered. Now the Site Picker component searches when 1 char is entered. This way sites like HR, IT, ... can be found.