### PR TITLE
PropertyFieldListPicker control - remove debugger

### DIFF
--- a/src/services/SPListPickerService.ts
+++ b/src/services/SPListPickerService.ts
@@ -89,7 +89,6 @@ export default class SPListPickerService {
      
    
       if (this.props.contentTypeId) {
-        debugger;
         const testct=this.props.contentTypeId.toUpperCase();
         lists.value = lists.value.filter((l) => {
           for (let ct of l.ContentTypes) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

If I have the browser console open and my web part contains the FieldListPicker control, the debugger is started.

![image](https://user-images.githubusercontent.com/12131918/168758346-315dbe0f-f176-40c4-bbc7-f7759e616ad1.png)


