### PR TITLE
Fix for #446

### DIFF
--- a/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
+++ b/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
@@ -387,8 +387,9 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
       case CustomCollectionFieldType.custom:
           if (field.onCustomRender) {
             return field.onCustomRender(field, item[field.id], (fieldId, value) => {
-              this.onValueChanged(fieldId, value);
-              if(field.onGetErrorMessage) { this.fieldValidation(field, value); }
+              this.onValueChanged(fieldId, value).then(() => {
+                this.fieldValidation(field, value);
+              });
             }, item, item.uniqueId, this.onCustomFieldValidation);
           }
           return null;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes Fix for #446

#### What's in this Pull Request?

fieldValidation for custom fields did not get called if no onGetErrorMessage had been defined (it needs to be called on every change to update the validation state of required fields) and when it got called it did not await the setting of the new value so it did a check with the old value of the custom field.