### PR TITLE
Adding new translation for Field Issues label.

### DIFF
--- a/spfx-locale.csv
+++ b/spfx-locale.csv
@@ -70,6 +70,7 @@ CollectionDeleteRowButtonLabel;Delete the current row;Verwijder de huidige rij;S
 CollectionSaveAndAddButtonLabel;Add and save;Voeg toe en sla op;Ajouter et sauvegarder;Добавить и сохранить;x
 CollectionDataItemShowErrorsLabel;Show row errors;Problemen tonen;Afficher les erreurs de ligne;Отобразить ошибки для строки;x
 CollectionDataItemFieldRequiredLabel;Field is required.;Veld is verplicht.;Champ obligatoire;Это поле не может быть пустым.;x
+CollectionDataItemFieldIssuesLabel;Field issues:;Veld problemen:;Problèmes de champ:;Полевые проблемы:;x
 InvalidUrlError;The provided URL is not valid;De huidige URL is niet geldig;L'URL fournie n'est pas valide;Заданное значение не является корректной ссылкой;x
 DescriptionLabel;Description;Beschrijving;La description;Описание;x
 MoreInfoLabel;More info;Meer info;Plus d'informations;Подробнее;x

--- a/src/loc/bg-bg.js
+++ b/src/loc/bg-bg.js
@@ -74,6 +74,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "Добавяне и записване",
   "CollectionDataItemShowErrorsLabel": "Показване на грешките в реда",
   "CollectionDataItemFieldRequiredLabel": "Полето е задължително.",
+  "CollectionDataItemFieldIssuesLabel": "Проблеми на полето:",
   "InvalidUrlError": "Предоставеният URL адрес не е валиден",
   "DescriptionLabel": "Описание",
   "MoreInfoLabel": "Повече информация",

--- a/src/loc/ca-es.js
+++ b/src/loc/ca-es.js
@@ -74,6 +74,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "Afegir i desar",
   "CollectionDataItemShowErrorsLabel": "Mostra els errors de fila",
   "CollectionDataItemFieldRequiredLabel": "El camp és obligatori.",
+  "CollectionDataItemFieldIssuesLabel": "Problemes de camp:",
   "InvalidUrlError": "L'adreça URL proporcionada no és vàlida",
   "DescriptionLabel": "Descripció",
   "MoreInfoLabel": "Més informació",

--- a/src/loc/da-dk.js
+++ b/src/loc/da-dk.js
@@ -74,6 +74,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "Tilføje og gemme",
   "CollectionDataItemShowErrorsLabel": "Vis rækkefejl",
   "CollectionDataItemFieldRequiredLabel": "Feltet er påkrævet.",
+  "CollectionDataItemFieldIssuesLabel": "Feltproblemer:",
   "InvalidUrlError": "Den angivne URL-adresse er ikke gyldig",
   "DescriptionLabel": "Beskrivelse",
   "MoreInfoLabel": "Flere oplysninger",

--- a/src/loc/de-de.js
+++ b/src/loc/de-de.js
@@ -75,6 +75,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "Hinzufügen und Speichern",
   "CollectionDataItemShowErrorsLabel": "Zeilenfehler anzeigen",
   "CollectionDataItemFieldRequiredLabel": "Feld ist erforderlich.",
+  "CollectionDataItemFieldIssuesLabel": "Feldprobleme:",
   "InvalidUrlError": "Die angegebene URL ist ungültig.",
   "DescriptionLabel": "Beschreibung",
   "MoreInfoLabel": "Weitere Informationen",

--- a/src/loc/el-gr.js
+++ b/src/loc/el-gr.js
@@ -74,6 +74,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "Προσθήκη και αποθήκευση",
   "CollectionDataItemShowErrorsLabel": "Εμφάνιση σφαλμάτων γραμμής",
   "CollectionDataItemFieldRequiredLabel": "Απαιτείται πεδίο.",
+  "CollectionDataItemFieldIssuesLabel": "Θέματα πεδίου:",
   "InvalidUrlError": "Η παρεχόμενη διεύθυνση URL δεν είναι έγκυρη",
   "DescriptionLabel": "Περιγραφή",
   "MoreInfoLabel": "Περισσότερες πληροφορίες",

--- a/src/loc/en-gb.js
+++ b/src/loc/en-gb.js
@@ -76,6 +76,7 @@ define([], function ()
     CollectionSaveAndAddButtonLabel: "Add and save",
     CollectionDataItemShowErrorsLabel: "Show row errors",
     CollectionDataItemFieldRequiredLabel: "Field is required.",
+    CollectionDataItemFieldIssuesLabel: "Field issues:",
     InvalidUrlError: "The provided URL is not valid",
     DescriptionLabel: "Description",
     MoreInfoLabel: "More info",

--- a/src/loc/en-us.js
+++ b/src/loc/en-us.js
@@ -75,6 +75,7 @@ define([], function () {
     CollectionSaveAndAddButtonLabel: "Add and save",
     CollectionDataItemShowErrorsLabel: "Show row errors",
     CollectionDataItemFieldRequiredLabel: "Field is required.",
+    CollectionDataItemFieldIssuesLabel: "Field issues:",
     InvalidUrlError: "The provided URL is not valid",
     DescriptionLabel: "Description",
     MoreInfoLabel: "More info",

--- a/src/loc/es-es.js
+++ b/src/loc/es-es.js
@@ -74,6 +74,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "Añadir y guardar",
   "CollectionDataItemShowErrorsLabel": "Mostrar errores de fila",
   "CollectionDataItemFieldRequiredLabel": "El campo es obligatorio.",
+  "CollectionDataItemFieldIssuesLabel": "Problemas de campo:",
   "InvalidUrlError": "La URL proporcionada no es válida",
   "DescriptionLabel": "Descripción",
   "MoreInfoLabel": "Más información",

--- a/src/loc/et-ee.js
+++ b/src/loc/et-ee.js
@@ -74,6 +74,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "Lisamine ja salvestamine",
   "CollectionDataItemShowErrorsLabel": "Reatõrgete näitamine",
   "CollectionDataItemFieldRequiredLabel": "Väli on nõutav.",
+  "CollectionDataItemFieldIssuesLabel": "Põllu probleemid:",
   "InvalidUrlError": "Esitatud URL ei sobi",
   "DescriptionLabel": "Kirjeldus",
   "MoreInfoLabel": "Rohkem infot",

--- a/src/loc/fi-fi.js
+++ b/src/loc/fi-fi.js
@@ -74,6 +74,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "Lisää ja tallenna",
   "CollectionDataItemShowErrorsLabel": "Näytä rivivirheet",
   "CollectionDataItemFieldRequiredLabel": "Kenttä on pakollinen.",
+  "CollectionDataItemFieldIssuesLabel": "Kenttäongelmia:",
   "InvalidUrlError": "Annettu URL-osoite ei kelpaa",
   "DescriptionLabel": "Kuvaus",
   "MoreInfoLabel": "Lisää infoa",

--- a/src/loc/fr-fr.js
+++ b/src/loc/fr-fr.js
@@ -74,6 +74,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "Ajouter et sauvegarder",
   "CollectionDataItemShowErrorsLabel": "Afficher les erreurs de ligne",
   "CollectionDataItemFieldRequiredLabel": "Champ obligatoire",
+  "CollectionDataItemFieldIssuesLabel": "Problèmes de champ:",
   "InvalidUrlError": "L'URL fournie n'est pas valide",
   "DescriptionLabel": "La description",
   "MoreInfoLabel": "Plus d'informations",

--- a/src/loc/it-it.js
+++ b/src/loc/it-it.js
@@ -74,6 +74,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "Aggiungere e salvare",
   "CollectionDataItemShowErrorsLabel": "Mostra errori di riga",
   "CollectionDataItemFieldRequiredLabel": "Il campo è obbligatorio.",
+  "CollectionDataItemFieldIssuesLabel": "Problemi sul campo:",
   "InvalidUrlError": "L'URL fornito non è valido",
   "DescriptionLabel": "Descrizione",
   "MoreInfoLabel": "Maggiori informazioni",

--- a/src/loc/ja-jp.js
+++ b/src/loc/ja-jp.js
@@ -74,6 +74,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "追加と保存",
   "CollectionDataItemShowErrorsLabel": "行エラーの表示",
   "CollectionDataItemFieldRequiredLabel": "フィールドは必須です。",
+  "CollectionDataItemFieldIssuesLabel": "フィールドの問題",
   "InvalidUrlError": "指定された URL は無効です",
   "DescriptionLabel": "説明",
   "MoreInfoLabel": "詳細",

--- a/src/loc/lt-lt.js
+++ b/src/loc/lt-lt.js
@@ -74,6 +74,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "Pridėti ir įrašyti",
   "CollectionDataItemShowErrorsLabel": "Rodyti eilutės klaidas",
   "CollectionDataItemFieldRequiredLabel": "Laukas yra būtinas.",
+  "CollectionDataItemFieldIssuesLabel": "Lauko problemos:",
   "InvalidUrlError": "Pateiktas URL neleistinas",
   "DescriptionLabel": "Aprašymas / kontrolė",
   "MoreInfoLabel": "Daugiau informacijos",

--- a/src/loc/mystrings.d.ts
+++ b/src/loc/mystrings.d.ts
@@ -87,6 +87,7 @@ declare interface IPropertyControlStrings {
   CollectionSaveAndAddButtonLabel: string;
   CollectionDataItemShowErrorsLabel: string;
   CollectionDataItemFieldRequiredLabel: string;
+  CollectionDataItemFieldIssuesLabel: string;
   InvalidUrlError: string;
 
   // Property Editor

--- a/src/loc/nb-no.js
+++ b/src/loc/nb-no.js
@@ -74,6 +74,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "Legge til og lagre",
   "CollectionDataItemShowErrorsLabel": "Vis radfeil",
   "CollectionDataItemFieldRequiredLabel": "Feltet er obligatorisk.",
+  "CollectionDataItemFieldIssuesLabel": "Feltproblemer:",
   "InvalidUrlError": "Den angitte URL-adressen er ikke gyldig",
   "DescriptionLabel": "Beskrivelse",
   "MoreInfoLabel": "Mer info",

--- a/src/loc/nl-nl.js
+++ b/src/loc/nl-nl.js
@@ -74,6 +74,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "Voeg toe en sla op",
   "CollectionDataItemShowErrorsLabel": "Problemen tonen",
   "CollectionDataItemFieldRequiredLabel": "Veld is verplicht.",
+  "CollectionDataItemFieldIssuesLabel": "Veld problemen:",
   "InvalidUrlError": "De huidige URL is niet geldig",
   "DescriptionLabel": "Beschrijving",
   "MoreInfoLabel": "Meer info",

--- a/src/loc/no.js
+++ b/src/loc/no.js
@@ -73,6 +73,7 @@ define([], function() {
     CollectionSaveAndAddButtonLabel: "Legg til og lagre",
     CollectionDataItemShowErrorsLabel: "Vis radfeil",
     CollectionDataItemFieldRequiredLabel: "Feltet er påkrevet.",
+    CollectionDataItemFieldIssuesLabel: "Feltproblemer:",
     InvalidUrlError: "Den angitte nettadressen er ikke gyldig",
     DescriptionLabel: "Beskrivelse",
     MoreInfoLabel: "Mer informasjon",

--- a/src/loc/pl-pl.js
+++ b/src/loc/pl-pl.js
@@ -75,6 +75,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "Dodawanie i zapisywanie",
   "CollectionDataItemShowErrorsLabel": "Pokaż błędy wierszy",
   "CollectionDataItemFieldRequiredLabel": "Pole jest wymagane.",
+  "CollectionDataItemFieldIssuesLabel": "Zagadnienia terenowe:",
   "InvalidUrlError": "Podany adres URL jest nieprawidłowy",
   "DescriptionLabel": "Opis",
   "MoreInfoLabel": "Więcej informacji",

--- a/src/loc/pt-pt.js
+++ b/src/loc/pt-pt.js
@@ -74,6 +74,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "Adicionar e salvar",
   "CollectionDataItemShowErrorsLabel": "Mostrar erros de linha",
   "CollectionDataItemFieldRequiredLabel": "O campo é necessário.",
+  "CollectionDataItemFieldIssuesLabel": "Problemas de campo:",
   "InvalidUrlError": "O URL fornecido não é válido",
   "DescriptionLabel": "Descrição",
   "MoreInfoLabel": "Mais informações",

--- a/src/loc/ro-ro.js
+++ b/src/loc/ro-ro.js
@@ -74,6 +74,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "Adăugare și salvare",
   "CollectionDataItemShowErrorsLabel": "Afișare erori rând",
   "CollectionDataItemFieldRequiredLabel": "Câmpul este necesar.",
+  "CollectionDataItemFieldIssuesLabel": "Probleme de câmpul:",
   "InvalidUrlError": "URL-ul furnizat nu este valid",
   "DescriptionLabel": "Descrierea /",
   "MoreInfoLabel": "Mai multe informații",

--- a/src/loc/ru-ru.js
+++ b/src/loc/ru-ru.js
@@ -74,6 +74,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "Добавить и сохранить",
   "CollectionDataItemShowErrorsLabel": "Отобразить ошибки для строки",
   "CollectionDataItemFieldRequiredLabel": "Это поле не может быть пустым.",
+  "CollectionDataItemFieldIssuesLabel": "Полевые проблемы:",
   "InvalidUrlError": "Заданное значение не является корректной ссылкой",
   "DescriptionLabel": "Описание",
   "MoreInfoLabel": "Подробнее",

--- a/src/loc/sk-sk.js
+++ b/src/loc/sk-sk.js
@@ -74,6 +74,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "Pridanie a uloženie",
   "CollectionDataItemShowErrorsLabel": "Zobraziť chyby riadkov",
   "CollectionDataItemFieldRequiredLabel": "Pole je povinné.",
+  "CollectionDataItemFieldIssuesLabel": "Problémy v pole:",
   "InvalidUrlError": "Za predpokladu, že adresa URL nie je platná",
   "DescriptionLabel": "Popis / kontrol",
   "MoreInfoLabel": "Ďalšie informácie",

--- a/src/loc/sr-latn-rs.js
+++ b/src/loc/sr-latn-rs.js
@@ -74,6 +74,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "Dodavanje i čuvanje",
   "CollectionDataItemShowErrorsLabel": "Prikaži greške u redovima",
   "CollectionDataItemFieldRequiredLabel": "Polje je obavezno.",
+  "CollectionDataItemFieldIssuesLabel": "Problemi na polje:",
   "InvalidUrlError": "Navedena URL adresa nije važeća",
   "DescriptionLabel": "Opis",
   "MoreInfoLabel": "Više informacija",

--- a/src/loc/sv-se.js
+++ b/src/loc/sv-se.js
@@ -74,6 +74,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "Lägg till och spara",
   "CollectionDataItemShowErrorsLabel": "Visa radfel",
   "CollectionDataItemFieldRequiredLabel": "Fält är obligatoriskt.",
+  "CollectionDataItemFieldIssuesLabel": "Fältproblem:",
   "InvalidUrlError": "Den medföljande webbadressen är inte giltig",
   "DescriptionLabel": "Beskrivning",
   "MoreInfoLabel": "Mer info",

--- a/src/loc/tr-tr.js
+++ b/src/loc/tr-tr.js
@@ -74,6 +74,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "Ekle ve kaydet",
   "CollectionDataItemShowErrorsLabel": "Satır hatalarını göster",
   "CollectionDataItemFieldRequiredLabel": "Alan gereklidir.",
+  "CollectionDataItemFieldIssuesLabel": "Alan sorunları:",
   "InvalidUrlError": "Sağlanan URL geçerli değil",
   "DescriptionLabel": "Açıklama",
   "MoreInfoLabel": "Daha fazla bilgi",

--- a/src/loc/vi-vn.js
+++ b/src/loc/vi-vn.js
@@ -74,6 +74,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "Thêm và lưu",
   "CollectionDataItemShowErrorsLabel": "Hiện lỗi hàng",
   "CollectionDataItemFieldRequiredLabel": "Trường là bắt buộc.",
+  "CollectionDataItemFieldIssuesLabel": "Các vấn đề hiện trường:",
   "InvalidUrlError": "URL được cung cấp không hợp lệ",
   "DescriptionLabel": "Mô tả",
   "MoreInfoLabel": "Xem thêm thông tin",

--- a/src/loc/zh-cn.js
+++ b/src/loc/zh-cn.js
@@ -74,6 +74,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "添加并保存",
   "CollectionDataItemShowErrorsLabel": "显示数据项错误信息",
   "CollectionDataItemFieldRequiredLabel": "必填项",
+  "CollectionDataItemFieldIssuesLabel": "现场问题",
   "InvalidUrlError": "链接地址不正确",
   "DescriptionLabel": "简介",
   "MoreInfoLabel": "更多信息",

--- a/src/loc/zh-tw.js
+++ b/src/loc/zh-tw.js
@@ -74,6 +74,7 @@ define([], () => {
   "CollectionSaveAndAddButtonLabel": "添加和保存。",
   "CollectionDataItemShowErrorsLabel": "顯示行錯誤。",
   "CollectionDataItemFieldRequiredLabel": "欄位是必需的。",
+  "CollectionDataItemFieldIssuesLabel": "現場問題:",
   "InvalidUrlError": "提供的 URL 無效。",
   "DescriptionLabel": "描述。",
   "MoreInfoLabel": "更多資訊。",

--- a/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
+++ b/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
@@ -486,7 +486,7 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
                 {
                   (this.state.errorMsgs && this.state.errorMsgs.length > 0) && (
                     <div className={styles.errorMsgs}>
-                      <p>Field issues:</p>
+                      <p>{strings.CollectionDataItemFieldIssuesLabel}</p>
                       <ul>
                         {
                           this.state.errorMsgs.map((msg, idx) => (


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [X]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?
Add a new translation for the text "Field issues:" that is missing in the PropertyFieldCollectionData control.


