### PR TITLE
Fix for issue #501 - File Size Sort not working (text based instead of numeric)

### DIFF
--- a/src/services/FileBrowserService.ts
+++ b/src/services/FileBrowserService.ts
@@ -258,7 +258,7 @@ export class FileBrowserService {
       serverRelativeUrl: fileItem.FileRef,
       modified: new Date(fileItem["Modified."] ?? fileItem.Modified),
       modifiedFriendly: modifiedFriendly,
-      fileSize: fileItem.File_x0020_Size,
+      fileSize: parseInt(fileItem.File_x0020_Size),
       fileType: fileItem.File_x0020_Type,
       modifiedBy: fileItem.Editor[0].title,
       isFolder: fileItem.FSObjType === "1",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #501 

#### What's in this Pull Request?

Sets data type for file size as number, instead of string, so that sorts will work numerically instead of alphabetically.
