### PR TITLE
Fixed typos in the property pane field message control documentation

### DIFF
--- a/docs/documentation/docs/controls/PropertyFieldMessage.md
+++ b/docs/documentation/docs/controls/PropertyFieldMessage.md
@@ -13,6 +13,7 @@ This control generates a Message Bar that will show messages  .
 
 ```TypeScript
 import { PropertyFieldMessage} from '@pnp/spfx-property-controls/lib/PropertyFieldMessage';
+import { MessageBarType } from 'office-ui-fabric-react/lib/MessageBar';
 ```
 
 - Add the custom property control to the `groupFields` of the web part property pane configuration:
@@ -21,9 +22,9 @@ import { PropertyFieldMessage} from '@pnp/spfx-property-controls/lib/PropertyFie
  PropertyFieldMessage("", {
       key: "MessageKey",
       text: "Something went wrong... try later.",
-      messageType:  MessageBarType.error
-      isVisible:  true ,
-  }),
+      messageType: MessageBarType.error,
+      isVisible: true
+  })
 ```
 
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

While copying and pasting this control from the documentation, it gives a missing comma error `(',' expected.)`. And no available import statement for the MessageBar control.

![image](https://user-images.githubusercontent.com/52065929/195766845-c68faecf-1f64-4b7f-8e05-147bf69539d1.png)
