### PR TITLE
Fix for #503 - Server-Side Sorting

### DIFF
--- a/src/propertyFields/filePicker/filePickerControls/controls/FileBrowser/IFileBrowserState.ts
+++ b/src/propertyFields/filePicker/filePickerControls/controls/FileBrowser/IFileBrowserState.ts
@@ -19,4 +19,5 @@ export interface IFileBrowserState {
   filePickerResult: IFilePickerResult;
   columns: IColumn[];
   selectedView: ViewType;
+  currentSortColumnName: string;
 }

--- a/src/services/FileBrowserService.ts
+++ b/src/services/FileBrowserService.ts
@@ -258,7 +258,7 @@ export class FileBrowserService {
       serverRelativeUrl: fileItem.FileRef,
       modified: new Date(fileItem["Modified."] ?? fileItem.Modified),
       modifiedFriendly: modifiedFriendly,
-      fileSize: fileItem.File_x0020_Size,
+      fileSize: parseInt(fileItem.File_x0020_Size),
       fileType: fileItem.File_x0020_Type,
       modifiedBy: fileItem.Editor[0].title,
       isFolder: fileItem.FSObjType === "1",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #503 

#### What's in this Pull Request?
When working with a larger library, unless all the items in the location (library or folder) are loaded, sorting needs to take place server side, not just client side (otherwise it only sorts on the few items that have loaded, which is most likely incorrect compared with the total number of items).

This PR changes the code to first check if all server-side items are loaded, and if not, to apply the sort server-side.

Importantly, it fixes another bug that had not yet been identified - if the user had turned on a specific sort in one location (e.g. file size), then browses somewhere else (e.g. using the breadcrumb), then even though the sort indicator still appears above that column, it applies no sorting at all.

