### PR TITLE
List Picker - adds ContentTypes/Name to query

### DIFF
--- a/src/services/SPListPickerService.ts
+++ b/src/services/SPListPickerService.ts
@@ -37,7 +37,7 @@ export default class SPListPickerService {
     // If the running environment is SharePoint, request the lists REST service
     let queryUrl: string;
     if (this.props.contentTypeId) {
-      queryUrl = `${webAbsoluteUrl}/_api/lists?$select=Title,id,BaseTemplate,RootFolder/ServerRelativeUrl,ContentTypes/StringId&$expand=RootFolder&$expand=ContentTypes`;
+      queryUrl = `${webAbsoluteUrl}/_api/lists?$select=Title,id,BaseTemplate,RootFolder/ServerRelativeUrl,ContentTypes/StringId,ContentTypes/Name&$expand=RootFolder&$expand=ContentTypes`;
     } else {
       queryUrl = `${webAbsoluteUrl}/_api/lists?$select=Title,id,BaseTemplate,RootFolder/ServerRelativeUrl&$expand=RootFolder`;
     }


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ x]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

I have had several cases using the List Picker control where I wanted to filter on content type name, but can only filter directly on ID and I do not have the full ID. Since the plumbing is in place to provide part of the ID, which I will always have (0x0100, 0x0101, etc), simply added the ContentTypes/Name prop to the queryUrl in the getLibs() function when a contentTypeId prop is provided. This way, I can provide 0x0100 for Content Type ID, then use 
onListsRetrieved to further filter the lists by the content type name. If this is approved, I can add a note to the docs as well in case others have a similar need.

![image](https://user-images.githubusercontent.com/42096464/204917694-a7ffce8a-f157-4a67-8f4a-a7764655dc63.png)

