### PR TITLE
enhance: adds panelProps property to collection data to have control …

### DIFF
--- a/docs/documentation/docs/controls/PropertyFieldCollectionData.md
+++ b/docs/documentation/docs/controls/PropertyFieldCollectionData.md
@@ -139,6 +139,7 @@ The `PropertyFieldCollectionData` control can be configured with the following p
 | disableItemDeletion | boolean | no | Allows you to specify if users can delete already inserted items. | false |
 | panelClassName | string | no | Allows you to specify a custom CSS class name for the collection data panel. | |
 | tableClassName | string | no | Allows you to specify a custom CSS class name for the collection data table inside the panel. | |
+| panelProps | IPanelProps | no | Allows you to pass in props of the panel such as type and size to control the underlying panel. | |
 
 Interface `ICustomCollectionField`
 

--- a/src/propertyFields/collectionData/IPropertyFieldCollectionData.ts
+++ b/src/propertyFields/collectionData/IPropertyFieldCollectionData.ts
@@ -1,5 +1,7 @@
 import { IPropertyPaneCustomFieldProps } from "@microsoft/sp-property-pane";
 import { ICustomCollectionField } from ".";
+import { IPanelProps } from "office-ui-fabric-react";
+
 
 export interface IPropertyFieldCollectionDataProps {
   /**
@@ -66,6 +68,10 @@ export interface IPropertyFieldCollectionDataProps {
    * Allows you to specify a custom CSS class name for the collection data table inside the panel
    */
   tableClassName?: string;
+  /**
+   * Allow overriding panel props such as size, type, layerProps, etc.
+   */
+  panelProps?: IPanelProps;
 }
 
 export interface IPropertyFieldCollectionDataPropsInternal extends IPropertyPaneCustomFieldProps, IPropertyFieldCollectionDataProps {}

--- a/src/propertyFields/collectionData/PropertyFieldCollectionDataHost.tsx
+++ b/src/propertyFields/collectionData/PropertyFieldCollectionDataHost.tsx
@@ -1,22 +1,28 @@
-import * as React from 'react';
-import * as telemetry from '../../common/telemetry';
-import { IPropertyFieldCollectionDataHostProps, IPropertyFieldCollectionDataHostState } from './IPropertyFieldCollectionDataHost';
-import { DefaultButton } from 'office-ui-fabric-react/lib/components/Button';
-import { Panel, PanelType } from 'office-ui-fabric-react/lib/components/Panel';
-import { Label } from 'office-ui-fabric-react/lib/components/Label';
-import { CollectionDataViewer } from './collectionDataViewer';
-import FieldErrorMessage from '../errorMessage/FieldErrorMessage';
-import * as strings from 'PropertyControlStrings';
+import * as React from "react";
+import * as telemetry from "../../common/telemetry";
+import {
+  IPropertyFieldCollectionDataHostProps,
+  IPropertyFieldCollectionDataHostState,
+} from "./IPropertyFieldCollectionDataHost";
+import { DefaultButton } from "office-ui-fabric-react/lib/components/Button";
+import { Panel, PanelType } from "office-ui-fabric-react/lib/components/Panel";
+import { Label } from "office-ui-fabric-react/lib/components/Label";
+import { CollectionDataViewer } from "./collectionDataViewer";
+import FieldErrorMessage from "../errorMessage/FieldErrorMessage";
+import * as strings from "PropertyControlStrings";
 
-export class PropertyFieldCollectionDataHost extends React.Component<IPropertyFieldCollectionDataHostProps, IPropertyFieldCollectionDataHostState> {
+export class PropertyFieldCollectionDataHost extends React.Component<
+  IPropertyFieldCollectionDataHostProps,
+  IPropertyFieldCollectionDataHostState
+> {
   constructor(props: IPropertyFieldCollectionDataHostProps) {
     super(props);
 
     this.state = {
-      panelOpen: false
+      panelOpen: false,
     };
 
-    telemetry.track('PropertyFieldCollectionData', {});
+    telemetry.track("PropertyFieldCollectionData", {});
   }
 
   /**
@@ -24,53 +30,59 @@ export class PropertyFieldCollectionDataHost extends React.Component<IPropertyFi
    */
   private openPanel = (): void => {
     this.setState({
-      panelOpen: true
+      panelOpen: true,
     });
-  }
+  };
 
   /**
    * Closes the panel
    */
   private closePanel = (): void => {
     this.setState({
-      panelOpen: false
+      panelOpen: false,
     });
-  }
+  };
 
   /**
    * On save action
    */
-  private onSave = (items: any[]): void => { // eslint-disable-line @typescript-eslint/no-explicit-any
+  private onSave = (items: any[]): void => {
+    // eslint-disable-line @typescript-eslint/no-explicit-any
     this.props.onChanged(items);
     this.setState({
-      panelOpen: false
+      panelOpen: false,
     });
-  }
+  };
 
   public render(): JSX.Element {
     return (
       <div>
         <Label>{this.props.label}</Label>
 
-        <DefaultButton text={this.props.manageBtnLabel}
-                       onClick={this.openPanel}
-                       disabled={this.props.fields.length === 0 || this.props.disabled} />
+        <DefaultButton
+          text={this.props.manageBtnLabel}
+          onClick={this.openPanel}
+          disabled={this.props.fields.length === 0 || this.props.disabled}
+        />
 
-        {
-          this.props.fields.length === 0 && <FieldErrorMessage errorMessage={strings.CollectionDataEmptyFields} />
-        }
+        {this.props.fields.length === 0 && <FieldErrorMessage errorMessage={strings.CollectionDataEmptyFields} />}
 
-        <Panel isOpen={this.state.panelOpen}
-               onDismiss={this.closePanel}
-               type={PanelType.large}
-               headerText={this.props.panelHeader}
-               onOuterClick={()=>{ /* no-op; */ }}
-               className={`PropertyFieldCollectionData__panel ${this.props.panelClassName || ""}`}>
+        <Panel
+          isOpen={this.state.panelOpen}
+          onDismiss={this.closePanel}
+          type={PanelType.large}
+          headerText={this.props.panelHeader}
+          onOuterClick={() => {
+            /* no-op; */
+          }}
+          className={`PropertyFieldCollectionData__panel ${this.props.panelClassName || ""}`}
           {
-            this.props.panelDescription && (
-              <p className="PropertyFieldCollectionData__panel__description">{this.props.panelDescription}</p>
-            )
+            ...this.props.panelProps ?? {}
           }
+        >
+          {this.props.panelDescription && (
+            <p className="PropertyFieldCollectionData__panel__description">{this.props.panelDescription}</p>
+          )}
 
           <CollectionDataViewer {...this.props} fOnSave={this.onSave} fOnClose={this.closePanel} />
         </Panel>

--- a/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
+++ b/src/webparts/propertyControlsTest/PropertyControlsTestWebPart.ts
@@ -133,6 +133,7 @@ import PropertyControlsTest from './components/PropertyControlsTest';
 import {
   IPropertyControlsTestWebPartProps,
 } from './IPropertyControlsTestWebPartProps';
+import { PanelType } from 'office-ui-fabric-react';
 
 /**
  * Web part that can be used to test out the various property controls
@@ -380,6 +381,10 @@ export default class PropertyControlsTestWebPart extends BaseClientSideWebPart<I
                   disableItemCreation: false,
                   panelClassName: "MyAwesomePanelClassName",
                   tableClassName: "MyAwesomeTableClassName",
+                  panelProps: {
+                    type: PanelType.extraLarge,
+                    layerProps: {eventBubblingEnabled: true}                                        
+                  },
                   fields: [
                     {
                       id: "Title",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ x]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

This PR adds a new prop to PropertyFieldCollectionData called panelProps with type IPanelProps so we can have control over various aspects of the underlying panel, especially the size. I've updated the docs for this property if approved, I can create a PR for that change as well.
