### PR TITLE
Pnp file picker bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Releases
 
+## 3.15.0
+
+### Fixes
+
+- `Localization`: Errors in en-gb loc file [#582](https://github.com/pnp/sp-dev-fx-property-controls/pull/582)
+
+### Contributors
+
+Special thanks to our contributor: [andrew-lott](https://github.com/andrew-lott).
+
 ## 3.14.0
 
 ### Enhancements

--- a/docs/documentation/docs/about/release-notes.md
+++ b/docs/documentation/docs/about/release-notes.md
@@ -1,5 +1,15 @@
 # Releases
 
+## 3.15.0
+
+### Fixes
+
+- `Localization`: Errors in en-gb loc file [#582](https://github.com/pnp/sp-dev-fx-property-controls/pull/582)
+
+### Contributors
+
+Special thanks to our contributor: [andrew-lott](https://github.com/andrew-lott).
+
 ## 3.14.0
 
 ### Enhancements

--- a/src/common/telemetry/version.ts
+++ b/src/common/telemetry/version.ts
@@ -1,1 +1,1 @@
-export const version: string = "3.14.0";
+export const version: string = "3.15.0";

--- a/src/propertyFields/filePicker/filePickerControls/OneDriveFilesTab/OneDriveFilesTab.tsx
+++ b/src/propertyFields/filePicker/filePickerControls/OneDriveFilesTab/OneDriveFilesTab.tsx
@@ -90,7 +90,7 @@ export class OneDriveFilesTab extends React.Component<IOneDriveFilesTabProps, IO
     return (
       <div className={styles.tabContainer}>
         <div className={styles.tabHeaderContainer}>
-          <Breadcrumb items={breadcrumbItems} /*onRenderItem={this.renderBreadcrumbItem}*/ className={styles.breadcrumbNav}/>
+          <Breadcrumb items={breadcrumbItems} /*onRenderItem={this.renderBreadcrumbItem}*/ className={styles.breadcrumbNav} />
         </div>
         <div className={styles.tabFiles}>
           {libraryAbsolutePath !== undefined &&
@@ -101,7 +101,9 @@ export class OneDriveFilesTab extends React.Component<IOneDriveFilesTabProps, IO
               libraryName={libraryTitle}
               libraryId={libraryId}
               folderPath={folderPath}
-              accepts={accepts} />}
+              accepts={accepts}
+              context={this.props.context}
+            />}
         </div>
         <div className={styles.actionButtonsContainer}>
           <div className={styles.actionButtons}>

--- a/src/propertyFields/filePicker/filePickerControls/SiteFilePickerTab/SiteFilePickerTab.tsx
+++ b/src/propertyFields/filePicker/filePickerControls/SiteFilePickerTab/SiteFilePickerTab.tsx
@@ -59,7 +59,9 @@ export default class SiteFilePickerTab extends React.Component<ISiteFilePickerTa
               libraryName={this.state.libraryTitle}
               libraryId={this.state.libraryId}
               folderPath={this.state.libraryPath}
-              accepts={this.props.accepts} />}
+              accepts={this.props.accepts}
+              context={this.props.context}
+            />}
         </div>
         <div className={styles.actionButtonsContainer}>
           <div className={styles.actionButtons}>

--- a/src/propertyFields/filePicker/filePickerControls/controls/FileBrowser/FileBrowser.tsx
+++ b/src/propertyFields/filePicker/filePickerControls/controls/FileBrowser/FileBrowser.tsx
@@ -198,6 +198,7 @@ export class FileBrowser extends React.Component<IFileBrowserProps, IFileBrowser
                       onFolderOpen={this._handleOpenFolder}
                       onFileSelected={this._itemSelectionChanged}
                       onNextPageDataRequest={this._loadNextDataRequest}
+                      context={this.props.context}
                     />)
                 }
               </ScrollablePane>

--- a/src/propertyFields/filePicker/filePickerControls/controls/FileBrowser/IFileBrowserProps.ts
+++ b/src/propertyFields/filePicker/filePickerControls/controls/FileBrowser/IFileBrowserProps.ts
@@ -1,3 +1,4 @@
+import { BaseComponentContext } from "@microsoft/sp-component-base";
 import { FileBrowserService } from "../../../../../services/FileBrowserService";
 import { IFile } from "../../../../../services/FileBrowserService.types";
 import { IFilePickerResult } from "../../FilePicker.types";
@@ -8,6 +9,7 @@ export interface IFileBrowserProps {
   libraryId: string;
   folderPath: string;
   accepts: string[];
+  context: BaseComponentContext;
   onChange: (filePickerResult: IFilePickerResult) => void;
   onOpenFolder: (folder: IFile) => void;
 }

--- a/src/propertyFields/filePicker/filePickerControls/controls/FolderTile/FolderTile.tsx
+++ b/src/propertyFields/filePicker/filePickerControls/controls/FolderTile/FolderTile.tsx
@@ -3,7 +3,7 @@ import styles from './FolderTile.module.scss';
 import { css } from 'office-ui-fabric-react/lib/Utilities';
 import { Icon, IconType } from 'office-ui-fabric-react/lib/Icon';
 import * as strings from 'PropertyControlStrings';
-import { ScreenWidthMinLarge  } from 'office-ui-fabric-react/lib/Styling';
+import { ScreenWidthMinLarge } from 'office-ui-fabric-react/lib/Styling';
 import { IFolderTileProps } from './IFolderTileProps';
 
 export class FolderTile extends React.Component<IFolderTileProps> {
@@ -16,6 +16,12 @@ export class FolderTile extends React.Component<IFolderTileProps> {
       .replace('{1}', item.modifiedFriendly)
       .replace('{2}', item.modifiedBy)
       .replace('{3}', `${item.totalFileCount}`);
+
+    // Get the user's locale
+    const userLocale = this.props.context.pageContext
+      ? this.props.context.pageContext.cultureInfo.currentCultureName || this.props.context.pageContext.cultureInfo.currentUICultureName // gets the language / locale of the user
+      : "en-US"; // defaults to American English
+
     return (
       <div
         aria-selected={isSelected}
@@ -28,7 +34,7 @@ export class FolderTile extends React.Component<IFolderTileProps> {
         data-is-sub-focuszone={true}
         data-disable-click-on-enter={true}
         data-selection-index={index}
-        onClick={(_event)=>this.props.onItemInvoked(item)}
+        onClick={(_event) => this.props.onItemInvoked(item)}
       >
         <div
           className={styles.link}
@@ -78,7 +84,7 @@ export class FolderTile extends React.Component<IFolderTileProps> {
             </span>
             <span className={styles.activity} id={`Tile-activity${index}`}>
               <span className={css(styles.signalField, styles.compact)}>
-                <span className={styles.signalFieldValue}>{item.modified}</span>
+                <span className={styles.signalFieldValue}>{item.modified.toLocaleDateString(userLocale)}</span>
               </span>
             </span>
           </span>

--- a/src/propertyFields/filePicker/filePickerControls/controls/FolderTile/IFolderTileProps.ts
+++ b/src/propertyFields/filePicker/filePickerControls/controls/FolderTile/IFolderTileProps.ts
@@ -1,5 +1,6 @@
 import { IDimensions } from "../../../../../services/IOneDriveService";
 import { IFile } from "../../../../../services/FileBrowserService.types";
+import { BaseComponentContext } from "@microsoft/sp-component-base";
 
 export interface IFolderTileProps {
   item: IFile;
@@ -8,4 +9,5 @@ export interface IFolderTileProps {
   pageWidth: number;
   onItemInvoked: (item: IFile) => void;
   tileDimensions: IDimensions;
+  context: BaseComponentContext;
 }

--- a/src/propertyFields/filePicker/filePickerControls/controls/TilesList/ITilesListProps.ts
+++ b/src/propertyFields/filePicker/filePickerControls/controls/TilesList/ITilesListProps.ts
@@ -2,12 +2,14 @@ import { FileBrowserService } from "../../../../../services/FileBrowserService";
 import { IFile } from "../../../../../services/FileBrowserService.types";
 import { Selection } from 'office-ui-fabric-react/lib/Selection';
 import { IFilePickerResult } from "../../FilePicker.types";
+import { BaseComponentContext } from "@microsoft/sp-component-base";
 
 export interface ITilesListProps {
   fileBrowserService: FileBrowserService;
   filePickerResult: IFilePickerResult;
   selection: Selection;
   items: IFile[];
+  context: BaseComponentContext;
 
   onFolderOpen: (item: IFile) => void;
   onFileSelected: (item: IFile) => void;

--- a/src/propertyFields/filePicker/filePickerControls/controls/TilesList/TilesList.tsx
+++ b/src/propertyFields/filePicker/filePickerControls/controls/TilesList/TilesList.tsx
@@ -118,7 +118,7 @@ export class TilesList extends React.Component<ITilesListProps> {
 
     // Group items by folders and files
     let pageLength: number = 0;
-    for (let index = itemIndex; index < items.length; index++) {
+    for (let index = itemIndex;index < items.length;index++) {
       const element = items[index];
       if (element && element.isFolder === isFolder) {
         pageLength++;
@@ -214,6 +214,7 @@ export class TilesList extends React.Component<ITilesListProps> {
                     height: this._rowHeight - TILE_HORZ_PADDING
                   }}
                   onItemInvoked={(itemInvoked: IFile) => this._handleItemInvoked(itemInvoked)}
+                  context={this.props.context} // used to get page locale
                 />
                 :
                 <DocumentTile


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Fix for issue #562 
PR to go with my comment for the issue here: 
https://github.com/pnp/sp-dev-fx-property-controls/issues/562#issuecomment-1778810710 


The problem is that the span tag in FolderTitle.tsx component can't render the Date object which is being passed with 'item.modified'. The FolderTile.tsx is a child component in TilesList.tsx which is why the Tiles layout closes the property pane when that layout is selected.

![image](https://github.com/pnp/sp-dev-fx-property-controls/assets/64632596/b8a4caf5-b9ac-4fa8-8583-7aea6fd6cb43)

My error message was that React cannot render an object or something to that effect. Unfortunately, I don't have a screenshot of the error to show here.

To fix this behaviour, .toLocaleDateString() is called to display the date that was intended in the 'item.modified' Date object and get the site locale by prop-drilling to pass the SharePoint context value .currentCultureName. In case context is undefined or null, I'm setting a fallback to 'en-US'.

![image](https://github.com/pnp/sp-dev-fx-property-controls/assets/64632596/ae1cb477-53f0-4541-acef-8185a7d3e495)

What the folder with a date looks like with an 'en-UK' locale set on the workbench:
![image](https://github.com/pnp/sp-dev-fx-property-controls/assets/64632596/d0d1a68a-2e21-4aa8-aa8a-cd6b0fe4f16a)
