### PR TITLE
fix text selection in code editor and monaco editor

### DIFF
--- a/src/propertyFields/codeEditor/PropertyFieldCodeEditorHost.tsx
+++ b/src/propertyFields/codeEditor/PropertyFieldCodeEditorHost.tsx
@@ -216,6 +216,7 @@ export default class PropertyFieldCodeEditorHost extends React.Component<IProper
               boxSizing: 'border-box'
             }
           }}
+          layerProps={{ eventBubblingEnabled: true }}
           onRenderFooterContent={() => (
             <div className={styles.actions}>
               <div className="ms-Grid" dir="ltr">

--- a/src/propertyFields/monacoEditor/PropertyFieldMonacoEditorHost.tsx
+++ b/src/propertyFields/monacoEditor/PropertyFieldMonacoEditorHost.tsx
@@ -103,7 +103,9 @@ export default class PropertyFieldMonacoEditorHost extends React.Component<
           }}
           headerText={strings.MonacoEditorPanelTitle}
           onRenderFooterContent={this.onRenderFooterContent}
-          isFooterAtBottom={true}>
+          isFooterAtBottom={true}
+          layerProps={{ eventBubblingEnabled: true }}
+        >
           <div className={this.controlClasses.headerTitle}>
             <MonacoEditor {...this.props} onValueChange={ this._onValueChange}/>
           </div>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

The Fluent UI panel component doesn't propagate certain events making text selection not work in the code editor and the monaco text editor. This can be fixed by setting `eventBubblingEnabled` to `true` for the `layerProps` of the panel.