### PR TITLE
Bugfix for issue #592

### DIFF
--- a/src/propertyFields/choiceGroupWithCallout/PropertyFieldChoiceGroupWithCallout.ts
+++ b/src/propertyFields/choiceGroupWithCallout/PropertyFieldChoiceGroupWithCallout.ts
@@ -56,7 +56,7 @@ class PropertyFieldChoiceGroupWithCalloutBuilder implements IPropertyPaneField<I
         ReactDOM.unmountComponentAtNode(elem);
     }
 
-    private _onChanged(option: IChoiceGroupOption): void {
+    private _onChanged(ev?: React.FormEvent<HTMLElement | HTMLInputElement>, option?: IChoiceGroupOption): void {
         if (this._onChangeCallback) {
             this._onChangeCallback(this.targetProperty, option.key);
         }

--- a/src/propertyFields/choiceGroupWithCallout/PropertyFieldChoiceGroupWithCalloutHost.tsx
+++ b/src/propertyFields/choiceGroupWithCallout/PropertyFieldChoiceGroupWithCalloutHost.tsx
@@ -18,10 +18,11 @@ export default class PropertyFieldToggleWithCalloutHost extends React.Component<
     }
 
     public render(): JSX.Element {
+        const defaultSelectedKey: any[] = this.props.options.filter((value: any) => { return value.checked; })
         return (
             <div>
                 <PropertyFieldHeader {...(this.props as IPlaceholderWithCalloutProps)} />
-                <ChoiceGroup {...omit(this.props, ['label'])} />
+                <ChoiceGroup {...omit(this.props, ['label'])} defaultSelectedKey={defaultSelectedKey.length > 0 ? defaultSelectedKey[0].key : ''} />
             </div>
         );
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #592

#### What's in this Pull Request?

Bugfix for issue #592
Switching from office-ui-fabric-react to @fluentui/react caused incompatibilities. Choice options no longer use "checked" but "defaultSelectedKey" and onChange has two parameters instead of one.