### PR TITLE
Fix root site org asset library showing no items in file picker

### DIFF
--- a/src/services/OrgAssetsService.ts
+++ b/src/services/OrgAssetsService.ts
@@ -48,15 +48,20 @@ export class OrgAssetsService extends FileBrowserService {
   public getListItemsByListId = async (listId: string, folderPath: string, acceptedFilesExtensions?: string[], nextPageQueryStringParams?: string): Promise<FilesQueryResult> => {
     let filesQueryResult: FilesQueryResult = { items: [], nextHref: null };
     try {
+      let orgAssetLibraryServerRelativeUrlWithoutTrailingSlash = this._orgAssetsLibraryServerRelativeSiteUrl;
+      if (orgAssetLibraryServerRelativeUrlWithoutTrailingSlash.charAt(orgAssetLibraryServerRelativeUrlWithoutTrailingSlash.length - 1) === '/') {
+        orgAssetLibraryServerRelativeUrlWithoutTrailingSlash = orgAssetLibraryServerRelativeUrlWithoutTrailingSlash.slice(0, -1);
+      }
+
       // Retrieve Lib path from folder path
       if (folderPath.charAt(0) !== "/") {
         folderPath = `/${folderPath}`;
       }
       // Remove all the rest of the folder path
-      let libName = folderPath.replace(`${this._orgAssetsLibraryServerRelativeSiteUrl}/`, "");
-      libName = libName.split("/")[0];
-      // Buil absolute library URL
-      const libFullUrl = this.buildAbsoluteUrl(`${this._orgAssetsLibraryServerRelativeSiteUrl}/${libName}`);
+      let libName = folderPath.replace(`${orgAssetLibraryServerRelativeUrlWithoutTrailingSlash}/`, "");
+      libName = libName.split("/")[0]; // Get only library name, if navigated to sub folder in the picker
+      // Build absolute library URL
+      const libFullUrl = this.buildAbsoluteUrl(`${orgAssetLibraryServerRelativeUrlWithoutTrailingSlash}/${libName}`);
 
       let queryStringParams: string = "";
       // Do not pass FolderServerRelativeUrl as query parameter
@@ -104,7 +109,7 @@ export class OrgAssetsService extends FileBrowserService {
 
   private _parseOrgAssetsLibraryItem = (libItem: any): ILibrary => { // eslint-disable-line @typescript-eslint/no-explicit-any
     const orgAssetsLibrary: ILibrary = {
-      absoluteUrl: this.buildAbsoluteUrl(libItem.LibraryUrl.DecodedUrl),
+      absoluteUrl: this.buildAbsoluteUrl(`/${libItem.LibraryUrl.DecodedUrl}`),
       title: libItem.DisplayName,
       id: libItem.ListId,
       serverRelativeUrl: libItem.LibraryUrl.DecodedUrl,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ X ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | #595 

#### Issue
- When the file picker is used to pick files from an organizational asset library on the SharePoint root site, no files are shown.

#### What's in this Pull Request?
1. Fix library name missing from the listFullUrl query parameter, which caused the REST API request to retrieve items from an organizational assets library to fail, on the SharePoint root site.
1. Also fix an error in the _parseOrgAssetsLibraryItem function, which causes the absoluteUrl property to lack one / after the root SharePoint URL (e.g. "https://TENANT.sharepoint.comOrganizational Media Library" or "https://TENANT.sharepoint.comsites/OrgAssetsSite/Branding images"). Since this is faulty for org asset libraries on ALL sites, I don't think this property is used, otherwise it would have caused problems already.
   - See screenshots below for the behaviour.

**Explanation of the error in file picker of organizational asset library:**
1. The relative url of the root site is /, which causes a / to still be present in the library name, after removal of the site relative url.
1. This is turn causes the library name to be an empty string after splitting the library name on /.
1. When building the API request URL for retrieving the organizational assets library items, the library name is therefore missing from the listFullUrl query parameter (e.g. "https://TENANT.sharepoint.com//" instead of "https://TENANT.sharepoint.com/Organizational Media Library").
- In addition to this, the listFullUrl query parameter can't contain two slashes in front of the library name (e.g. "https://TENANT.sharepoint.com//Organizational Media Library") This also causes the request to fail).
- This error would also happen if the site server relative url (_orgAssetsLibraryServerRelativeSiteUrl) starts with a slash.

#### Screenshots / GIFs
**File picker error**
Left side has a org. assets library on a site under /sites/, while the right one has one on the root SharePoint site. The gifs are roughly 1,5 minutes long.
![pnp-595-comparison-rec](https://github.com/pnp/sp-dev-fx-property-controls/assets/4593278/85d54eab-1097-4684-9acf-0eedb62e7c36)
_Showcasing the current behavior, stepping through the code and showing property values._

![pnp-595-comparison-fix-rec](https://github.com/pnp/sp-dev-fx-property-controls/assets/4593278/544f6158-fbd1-4308-8e60-c67187b5c9c0)
_Showcasing the fixed behavior, stepping through the code and showing property values._

**_parseOrgAssetsLibraryItem**
![pnp-595-parseOrgAssetsLibraryItem-root](https://github.com/pnp/sp-dev-fx-property-controls/assets/4593278/74f353c7-e895-4c5c-9bb2-22547a464295)
_Showing faulty absoluteUrl property on the org asset library, when retrieving from the root SharePoint site._

![pnp-595-parseOrgAssetsLibraryItem-site](https://github.com/pnp/sp-dev-fx-property-controls/assets/4593278/6fc24a73-6e70-4814-92ea-cdbc80d924a2)
_Showing faulty absoluteUrl property on the org asset library, when retrieving from a site under /sites/._

![pnp-595-parseOrgAssetsLibraryItem-fixed](https://github.com/pnp/sp-dev-fx-property-controls/assets/4593278/c228dec9-bc16-4336-bb7f-81da53296541)
_Showing fixed property._