### PR TITLE
toRelativeUrl returns proper relative url in case of root site

### DIFF
--- a/src/helpers/GeneralHelper.ts
+++ b/src/helpers/GeneralHelper.ts
@@ -356,5 +356,5 @@ export const toRelativeUrl = (absoluteUrl: string): string => {
     return '';
   }
 
-  return absoluteUrl.replace(/^(?:\/\/|[^/]+)*\//, '/');
+  return new URL(absoluteUrl).pathname;
 };


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

On a root site (i.e. https://customer.sharepoint.com) the `toRelativeUrl` helper now returns `/` instead of returning a relative url with `//` appended to the domain (`//customer.sharepoint.com`). On non-root sites the behaviour remains as-is. 
