### PR TITLE
build: fix fluentui imports for webpack

### DIFF
--- a/src/common/placeholderWithCallout/PlaceholderWithCallout.tsx
+++ b/src/common/placeholderWithCallout/PlaceholderWithCallout.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Callout, DirectionalHint } from '@fluentui/react/lib/components/Callout';
+import { Callout, DirectionalHint } from '@fluentui/react/lib/Callout';
 import { IPlaceholderWithCalloutProps, IPlaceholderWithCalloutState } from './IPlaceholderWithCallout';
 import { CalloutTriggers } from '../callout/Callout';
 import { getIconClassName } from '@fluentui/react/lib/Styling';

--- a/src/common/propertyFieldHeader/PropertyFieldHeader.tsx
+++ b/src/common/propertyFieldHeader/PropertyFieldHeader.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Callout, DirectionalHint } from '@fluentui/react/lib/components/Callout';
+import { Callout, DirectionalHint } from '@fluentui/react/lib/Callout';
 import { IPropertyFieldHeaderProps, IPropertyFieldHeaderState, CalloutTriggers } from './IPropertyFieldHeader';
 import { getIconClassName } from '@fluentui/react/lib/Styling';
 import { css } from '@fluentui/react/lib/Utilities';

--- a/src/propertyFields/buttonWithCallout/IPropertyFieldButtonWithCalloutHost.ts
+++ b/src/propertyFields/buttonWithCallout/IPropertyFieldButtonWithCalloutHost.ts
@@ -1,5 +1,5 @@
 import { IPlaceholderWithCalloutProps } from '../../common/placeholderWithCallout/IPlaceholderWithCallout';
-import { IButtonProps } from '@fluentui/react/lib/components/Button';
+import { IButtonProps } from '@fluentui/react/lib/Button';
 
 /**
  * PropertyFieldButtonWithCalloutHost properties interface

--- a/src/propertyFields/buttonWithCallout/PropertyFieldButtonWithCallout.ts
+++ b/src/propertyFields/buttonWithCallout/PropertyFieldButtonWithCallout.ts
@@ -8,7 +8,7 @@ import {
 import PropertyFieldButtonHost from './PropertyFieldButtonWithCalloutHost';
 
 import { IPropertyFieldButtonWithCalloutPropsInternal, IPropertyFieldButtonWithCalloutProps } from './IPropertyFieldButtonWithCallout';
-import { ButtonType } from '@fluentui/react/lib/components/Button';
+import { ButtonType } from '@fluentui/react/lib/Button';
 
 import omit from 'lodash/omit';
 

--- a/src/propertyFields/buttonWithCallout/PropertyFieldButtonWithCalloutHost.tsx
+++ b/src/propertyFields/buttonWithCallout/PropertyFieldButtonWithCalloutHost.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button } from '@fluentui/react/lib/components/Button';
+import { Button } from '@fluentui/react/lib/Button';
 
 import PlaceholderWithCallout from '../../common/placeholderWithCallout/PlaceholderWithCallout';
 

--- a/src/propertyFields/checkboxWithCallout/IPropertyFieldCheckboxWithCalloutHost.ts
+++ b/src/propertyFields/checkboxWithCallout/IPropertyFieldCheckboxWithCalloutHost.ts
@@ -1,5 +1,5 @@
 import { IPlaceholderWithCalloutProps } from '../../common/placeholderWithCallout/IPlaceholderWithCallout';
-import { ICheckboxProps } from '@fluentui/react/lib/components/Checkbox';
+import { ICheckboxProps } from '@fluentui/react/lib/Checkbox';
 
 /**
  * PropertyFieldCheckboxWithCalloutHost properties interface

--- a/src/propertyFields/checkboxWithCallout/PropertyFieldCheckboxWithCalloutHost.tsx
+++ b/src/propertyFields/checkboxWithCallout/PropertyFieldCheckboxWithCalloutHost.tsx
@@ -5,7 +5,7 @@ import type { IPlaceholderWithCalloutProps } from '../../common/placeholderWithC
 
 import { IPropertyFieldCheckboxWithCalloutHostProps } from './IPropertyFieldCheckboxWithCalloutHost';
 import * as telemetry from '../../common/telemetry';
-import { Checkbox } from '@fluentui/react/lib/components/Checkbox';
+import { Checkbox } from '@fluentui/react/lib/Checkbox';
 
 /**
  * Renders the control for PropertyFieldCheckboxWithCallout component

--- a/src/propertyFields/choiceGroupWithCallout/IPropertyFieldChoiceGroupWithCalloutHost.ts
+++ b/src/propertyFields/choiceGroupWithCallout/IPropertyFieldChoiceGroupWithCalloutHost.ts
@@ -1,5 +1,5 @@
 import { IPropertyFieldHeaderCalloutProps } from '../../common/propertyFieldHeader/IPropertyFieldHeader';
-import { IChoiceGroupProps } from '@fluentui/react/lib/components/ChoiceGroup';
+import { IChoiceGroupProps } from '@fluentui/react/lib/ChoiceGroup';
 
 /**
  * PropertyFieldChoiceGroupWithCalloutHost properties interface

--- a/src/propertyFields/choiceGroupWithCallout/PropertyFieldChoiceGroupWithCallout.ts
+++ b/src/propertyFields/choiceGroupWithCallout/PropertyFieldChoiceGroupWithCallout.ts
@@ -4,7 +4,7 @@ import * as ReactDOM from 'react-dom';
 
 import omit from 'lodash/omit';
 
-import { IChoiceGroupOption } from '@fluentui/react/lib/components/ChoiceGroup';
+import { IChoiceGroupOption } from '@fluentui/react/lib/ChoiceGroup';
 import {
   IPropertyPaneField,
   PropertyPaneFieldType,

--- a/src/propertyFields/choiceGroupWithCallout/PropertyFieldChoiceGroupWithCalloutHost.tsx
+++ b/src/propertyFields/choiceGroupWithCallout/PropertyFieldChoiceGroupWithCalloutHost.tsx
@@ -6,7 +6,7 @@ import type { IPlaceholderWithCalloutProps } from '../../common/placeholderWithC
 
 import { IPropertyFieldChoiceGroupWithCalloutHostProps } from './IPropertyFieldChoiceGroupWithCalloutHost';
 import * as telemetry from '../../common/telemetry';
-import { ChoiceGroup } from '@fluentui/react/lib/components/ChoiceGroup';
+import { ChoiceGroup } from '@fluentui/react/lib/ChoiceGroup';
 
 export default class PropertyFieldToggleWithCalloutHost extends React.Component<
   IPropertyFieldChoiceGroupWithCalloutHostProps,

--- a/src/propertyFields/collectionData/ICustomCollectionField.ts
+++ b/src/propertyFields/collectionData/ICustomCollectionField.ts
@@ -1,5 +1,5 @@
 import { IDropdownOption } from '@fluentui/react/lib/Dropdown';
-import { ISelectableOption } from '@fluentui/react/lib/utilities/selectableOption/SelectableOption.types';
+import { ISelectableOption } from '@fluentui/react/lib/SelectableOption';
 import { IRenderFunction } from '@fluentui/react/lib/Utilities';
 import { CollectionIconFieldRenderMode } from './collectionIconField';
 

--- a/src/propertyFields/collectionData/PropertyFieldCollectionDataHost.tsx
+++ b/src/propertyFields/collectionData/PropertyFieldCollectionDataHost.tsx
@@ -4,9 +4,9 @@ import {
   IPropertyFieldCollectionDataHostProps,
   IPropertyFieldCollectionDataHostState,
 } from "./IPropertyFieldCollectionDataHost";
-import { DefaultButton } from "@fluentui/react/lib/components/Button";
-import { Panel, PanelType } from "@fluentui/react/lib/components/Panel";
-import { Label } from "@fluentui/react/lib/components/Label";
+import { DefaultButton } from "@fluentui/react/lib/Button";
+import { Panel, PanelType } from "@fluentui/react/lib/Panel";
+import { Label } from "@fluentui/react/lib/Label";
 import { CollectionDataViewer } from "./collectionDataViewer";
 import FieldErrorMessage from "../errorMessage/FieldErrorMessage";
 import * as strings from "PropertyControlStrings";

--- a/src/propertyFields/collectionData/collectionCheckboxField/CollectionCheckboxField.tsx
+++ b/src/propertyFields/collectionData/collectionCheckboxField/CollectionCheckboxField.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import styles from '../PropertyFieldCollectionDataHost.module.scss';
-import { Checkbox } from '@fluentui/react/lib/components/Checkbox';
+import { Checkbox } from '@fluentui/react/lib/Checkbox';
 import { IBaseCollectionFieldProps } from '../IBaseCollectionFIeldsProps';
 
 export interface ICollectionCheckboxFieldProps extends IBaseCollectionFieldProps { }

--- a/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
+++ b/src/propertyFields/collectionData/collectionDataItem/CollectionDataItem.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import styles from '../PropertyFieldCollectionDataHost.module.scss';
 import { ICollectionDataItemProps, ICollectionDataItemState } from '.';
-import { TextField } from '@fluentui/react/lib/components/TextField';
-import { Icon } from '@fluentui/react/lib/components/Icon';
-import { Link } from '@fluentui/react/lib/components/Link';
+import { TextField } from '@fluentui/react/lib/TextField';
+import { Icon } from '@fluentui/react/lib/Icon';
+import { Link } from '@fluentui/react/lib/Link';
 import * as strings from 'PropertyControlStrings';
 import { ICustomCollectionField, CustomCollectionFieldType } from '../ICustomCollectionField';
 import { FieldValidator } from '../FieldValidator';
-import { Dropdown, IDropdownOption } from '@fluentui/react/lib/components/Dropdown';
-import { Callout, DirectionalHint } from '@fluentui/react/lib/components/Callout';
+import { Dropdown, IDropdownOption } from '@fluentui/react/lib/Dropdown';
+import { Callout, DirectionalHint } from '@fluentui/react/lib/Callout';
 import { CollectionIconField } from '../collectionIconField';
 import { clone, findIndex, sortBy } from '@microsoft/sp-lodash-subset';
 import { CollectionNumberField } from '../collectionNumberField';
@@ -124,7 +124,7 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
    */
   private async checkAnyFieldCustomErrorMessage(item: any): Promise<boolean> { // eslint-disable-line @typescript-eslint/no-explicit-any
     const { fields, index } = this.props;
-    
+
     const validations = await Promise.all(fields.filter(f => f.onGetErrorMessage).map(async f => {
       const validation = await f.onGetErrorMessage(item[f.id], index, item);
       return this.storeFieldValidation(f.id, validation);
@@ -137,9 +137,9 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
    * Check if row is ready for save
    */
   private async checkRowIsValidForSave(item: any): Promise<boolean> { // eslint-disable-line @typescript-eslint/no-explicit-any
-    return this.checkAllRequiredFieldsValid(item) && 
+    return this.checkAllRequiredFieldsValid(item) &&
       this.checkAnyFieldContainsValue(item) &&
-      await this.checkAnyFieldCustomErrorMessage(item) && 
+      await this.checkAnyFieldCustomErrorMessage(item) &&
       this.checkAllFieldsAreValid();
   }
 
@@ -373,7 +373,7 @@ export class CollectionDataItem extends React.Component<ICollectionDataItemProps
         return <CollectionNumberField field={field} item={item} disableEdit={disableFieldOnEdit} fOnValueChange={this.onValueChanged} fValidation={this.fieldValidation} />;
       case CustomCollectionFieldType.fabricIcon:
         return <CollectionIconField renderMode={field.iconFieldRenderMode} field={field} item={item} disableEdit={disableFieldOnEdit} fOnValueChange={this.onValueChanged} fValidation={this.fieldValidation} />;
-      case CustomCollectionFieldType.color:    
+      case CustomCollectionFieldType.color:
         return <CollectionColorField field={field} item={item} disableEdit={disableFieldOnEdit} fOnValueChange={this.onValueChanged} fValidation={this.fieldValidation} />;
       case CustomCollectionFieldType.url:
         return <TextField placeholder={field.placeholder || field.title}

--- a/src/propertyFields/collectionData/collectionDataViewer/CollectionDataViewer.tsx
+++ b/src/propertyFields/collectionData/collectionDataViewer/CollectionDataViewer.tsx
@@ -3,8 +3,8 @@ import styles from '../PropertyFieldCollectionDataHost.module.scss';
 import { ICollectionDataViewerProps } from './ICollectionDataViewerProps';
 import { ICollectionDataViewerState } from './ICollectionDataViewerState';
 import { CollectionDataItem } from '../collectionDataItem';
-import { PrimaryButton, DefaultButton } from '@fluentui/react/lib/components/Button';
-import { Icon } from '@fluentui/react/lib/components/Icon';
+import { PrimaryButton, DefaultButton } from '@fluentui/react/lib/Button';
+import { Icon } from '@fluentui/react/lib/Icon';
 import * as strings from 'PropertyControlStrings';
 import { cloneDeep, sortBy } from '@microsoft/sp-lodash-subset';
 

--- a/src/propertyFields/collectionData/collectionIconField/CollectionIconField.tsx
+++ b/src/propertyFields/collectionData/collectionIconField/CollectionIconField.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import styles from '../PropertyFieldCollectionDataHost.module.scss';
 import { ICollectionIconFieldProps } from '.';
-import { TextField } from '@fluentui/react/lib/components/TextField';
-import { Icon } from '@fluentui/react/lib/components/Icon';
+import { TextField } from '@fluentui/react/lib/TextField';
+import { Icon } from '@fluentui/react/lib/Icon';
 import { ActionButton } from '@fluentui/react/lib/Button';
 import { IconSelector } from '../../../common/iconSelector/IconSelector';
 

--- a/src/propertyFields/dateTimePicker/HoursComponent.tsx
+++ b/src/propertyFields/dateTimePicker/HoursComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { IHoursComponentProps } from './IPropertyFieldDateTimePickerHost';
 import { TimeConvention } from './IPropertyFieldDateTimePicker';
-import { Dropdown, IDropdownOption } from '@fluentui/react/lib/components/Dropdown';
+import { Dropdown, IDropdownOption } from '@fluentui/react/lib/Dropdown';
 
 /**
  * Hours component, this renders the hours dropdown

--- a/src/propertyFields/dateTimePicker/IPropertyFieldDateTimePickerHost.ts
+++ b/src/propertyFields/dateTimePicker/IPropertyFieldDateTimePickerHost.ts
@@ -1,5 +1,5 @@
 import { IPropertyFieldDateTimePickerPropsInternal, TimeConvention } from './IPropertyFieldDateTimePicker';
-import { IDropdownOption } from '@fluentui/react/lib/components/Dropdown';
+import { IDropdownOption } from '@fluentui/react/lib/Dropdown';
 
 /**
  * PropertyFieldDateTimePickerHost properties interface

--- a/src/propertyFields/dateTimePicker/MinutesComponent.tsx
+++ b/src/propertyFields/dateTimePicker/MinutesComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ITimeComponentProps } from './IPropertyFieldDateTimePickerHost';
-import { Dropdown, IDropdownOption } from '@fluentui/react/lib/components/Dropdown';
+import { Dropdown, IDropdownOption } from '@fluentui/react/lib/Dropdown';
 
 /**
  * Minutes component, renders the minutes dropdown

--- a/src/propertyFields/dateTimePicker/SecondsComponent.tsx
+++ b/src/propertyFields/dateTimePicker/SecondsComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ITimeComponentProps } from './IPropertyFieldDateTimePickerHost';
-import { Dropdown, IDropdownOption } from '@fluentui/react/lib/components/Dropdown';
+import { Dropdown, IDropdownOption } from '@fluentui/react/lib/Dropdown';
 
 /**
  * Seconds component, renders the seconds dropdown

--- a/src/propertyFields/dropdownWithCallout/IPropertyFieldDropdownWithCalloutHost.ts
+++ b/src/propertyFields/dropdownWithCallout/IPropertyFieldDropdownWithCalloutHost.ts
@@ -1,5 +1,5 @@
 import { IPropertyFieldHeaderCalloutProps } from '../../common/propertyFieldHeader/IPropertyFieldHeader';
-import { IDropdownProps } from '@fluentui/react/lib/components/Dropdown';
+import { IDropdownProps } from '@fluentui/react/lib/Dropdown';
 
 /**
  * PropertyFieldDropdownWithCalloutHost properties interface

--- a/src/propertyFields/dropdownWithCallout/PropertyFieldDropdownWithCallout.ts
+++ b/src/propertyFields/dropdownWithCallout/PropertyFieldDropdownWithCallout.ts
@@ -9,7 +9,7 @@ import {
 import PropertyFieldDropdownHost from './PropertyFieldDropdownWithCalloutHost';
 import omit from 'lodash/omit';
 import { IPropertyFieldDropdownWithCalloutPropsInternal, IPropertyFieldDropdownWithCalloutProps } from './IPropertyFieldDropdownWithCallout';
-import { IDropdownOption } from '@fluentui/react/lib/components/Dropdown';
+import { IDropdownOption } from '@fluentui/react/lib/Dropdown';
 
 class PropertyFieldDropdownWithCalloutBuilder implements IPropertyPaneField<IPropertyFieldDropdownWithCalloutPropsInternal> {
   public targetProperty: string;

--- a/src/propertyFields/dropdownWithCallout/PropertyFieldDropdownWithCalloutHost.tsx
+++ b/src/propertyFields/dropdownWithCallout/PropertyFieldDropdownWithCalloutHost.tsx
@@ -4,9 +4,9 @@ import type { IPropertyFieldHeaderProps } from '../../common/propertyFieldHeader
 
 import { IPropertyFieldDropdownWithCalloutHostProps } from './IPropertyFieldDropdownWithCalloutHost';
 import * as telemetry from '../../common/telemetry';
-import { Dropdown, IDropdownProps, IDropdownOption } from '@fluentui/react/lib/components/Dropdown';
+import { Dropdown, IDropdownProps, IDropdownOption } from '@fluentui/react/lib/Dropdown';
 import { IPropertyPaneDropdownOption } from '@microsoft/sp-property-pane';
-import { SelectableOptionMenuItemType } from '@fluentui/react/lib/utilities/selectableOption/SelectableOption.types';
+import { SelectableOptionMenuItemType } from '@fluentui/react/lib/SelectableOption';
 import omit from 'lodash/omit';
 
 export default class PropertyFieldDropdownHost extends React.Component<IPropertyFieldDropdownWithCalloutHostProps, null> {

--- a/src/propertyFields/filePicker/PropertyFieldFilePickerHost.tsx
+++ b/src/propertyFields/filePicker/PropertyFieldFilePickerHost.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { IconButton } from "@fluentui/react/lib/components/Button";
+import { IconButton } from "@fluentui/react/lib/Button";
 import * as strings from 'PropertyControlStrings';
 
 import { FilePicker, IFilePickerResult } from './filePickerControls';

--- a/src/propertyFields/filePicker/filePickerControls/FilePicker.tsx
+++ b/src/propertyFields/filePicker/filePickerControls/FilePicker.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 import { IFilePickerProps } from './IFilePickerProps';
 import { IFilePickerState } from './IFilePickerState';
 
-import { PrimaryButton, ActionButton } from '@fluentui/react/lib/components/Button';
-import { Panel, PanelType } from '@fluentui/react/lib/components/Panel';
-import { Label } from '@fluentui/react/lib/components/Label';
+import { PrimaryButton, ActionButton } from '@fluentui/react/lib/Button';
+import { Panel, PanelType } from '@fluentui/react/lib/Panel';
+import { Label } from '@fluentui/react/lib/Label';
 import { Nav, INavLink, INavLinkGroup } from '@fluentui/react/lib/Nav';
 import { css } from '@fluentui/react/lib/Utilities';
 

--- a/src/propertyFields/filePicker/filePickerControls/LinkFilePickerTab/LinkFilePickerTab.tsx
+++ b/src/propertyFields/filePicker/filePickerControls/LinkFilePickerTab/LinkFilePickerTab.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { ILinkFilePickerTabProps, ILinkFilePickerTabState } from '.';
 import { GeneralHelper } from '../../../../helpers/GeneralHelper';
 import { IFilePickerResult } from '../FilePicker.types';
-import { PrimaryButton, DefaultButton } from '@fluentui/react/lib/components/Button';
+import { PrimaryButton, DefaultButton } from '@fluentui/react/lib/Button';
 import { TextField } from '@fluentui/react/lib/TextField';
 import { css } from '@fluentui/react/lib/Utilities';
 

--- a/src/propertyFields/filePicker/filePickerControls/OneDriveFilesTab/OneDriveFilesTab.types.ts
+++ b/src/propertyFields/filePicker/filePickerControls/OneDriveFilesTab/OneDriveFilesTab.types.ts
@@ -1,4 +1,4 @@
-import { IBreadcrumbItem } from "@fluentui/react/lib/components/Breadcrumb";
+import { IBreadcrumbItem } from "@fluentui/react/lib/Breadcrumb";
 import { IFile } from "../../../../services/FileBrowserService.types";
 
 export interface OneDriveFilesBreadcrumbItem extends IBreadcrumbItem {

--- a/src/propertyFields/filePicker/filePickerControls/RecentFilesTab/RecentFilesTab.tsx
+++ b/src/propertyFields/filePicker/filePickerControls/RecentFilesTab/RecentFilesTab.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { PrimaryButton, DefaultButton } from '@fluentui/react/lib/components/Button';
+import { PrimaryButton, DefaultButton } from '@fluentui/react/lib/Button';
 import { Spinner } from '@fluentui/react/lib/Spinner';
 import { FocusZone } from '@fluentui/react/lib/FocusZone';
 import { List } from '@fluentui/react/lib/List';

--- a/src/propertyFields/filePicker/filePickerControls/SiteFilePickerTab/SiteFilePickerTab.tsx
+++ b/src/propertyFields/filePicker/filePickerControls/SiteFilePickerTab/SiteFilePickerTab.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { findIndex } from '@microsoft/sp-lodash-subset';
 import { ISiteFilePickerTabProps, ISiteFilePickerTabState } from '.';
 import { DocumentLibraryBrowser, FileBrowser } from '../controls';
-import { PrimaryButton, DefaultButton } from '@fluentui/react/lib/components/Button';
+import { PrimaryButton, DefaultButton } from '@fluentui/react/lib/Button';
 import { Breadcrumb, IBreadcrumbItem } from '@fluentui/react/lib/Breadcrumb';
 import { ScrollablePane } from '@fluentui/react/lib/ScrollablePane';
 import { IFile, ILibrary } from '../../../../services/FileBrowserService.types';

--- a/src/propertyFields/filePicker/filePickerControls/UploadFilePickerTab/UploadFilePickerTab.tsx
+++ b/src/propertyFields/filePicker/filePickerControls/UploadFilePickerTab/UploadFilePickerTab.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { IUploadFilePickerTabProps, IUploadFilePickerTabState } from '.';
 import { IFilePickerResult } from '../FilePicker.types';
 import { GeneralHelper } from '../../../../helpers/GeneralHelper';
-import { PrimaryButton, DefaultButton } from '@fluentui/react/lib/components/Button';
+import { PrimaryButton, DefaultButton } from '@fluentui/react/lib/Button';
 import { css } from '@fluentui/react/lib/Utilities';
 import * as strings from 'PropertyControlStrings';
 import styles from './UploadFilePickerTab.module.scss';

--- a/src/propertyFields/filePicker/filePickerControls/WebSearchTab/WebSearchTab.tsx
+++ b/src/propertyFields/filePicker/filePickerControls/WebSearchTab/WebSearchTab.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { IWebSearchTabProps } from './IWebSearchTabProps';
 import { IWebSearchTabState } from './IWebSearchTabState';
 import { ISearchSuggestion, ImageSize, ImageAspect, ImageLicense, DEFAULT_SUGGESTIONS, MAX_ROW_HEIGHT, ROWS_PER_PAGE } from './WebSearchTab.types';
-import { PrimaryButton, DefaultButton } from '@fluentui/react/lib/components/Button';
+import { PrimaryButton, DefaultButton } from '@fluentui/react/lib/Button';
 import { Label } from '@fluentui/react/lib/Label';
 import { SearchBox } from '@fluentui/react/lib/SearchBox';
 import { Check } from '@fluentui/react/lib/Check';

--- a/src/propertyFields/filePicker/placeHolderControl/PlaceholderComponent.tsx
+++ b/src/propertyFields/filePicker/placeHolderControl/PlaceholderComponent.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { IPlaceholderProps, IPlaceholderState } from './IPlaceholderComponent';
 import { PrimaryButton } from '@fluentui/react/lib/Button';
 import styles from './PlaceholderComponent.module.scss';
-import { Icon } from '@fluentui/react/lib/components/Icon';
+import { Icon } from '@fluentui/react/lib/Icon';
 
 /**
  * Placeholder component

--- a/src/propertyFields/labelWithCallout/IPropertyFieldLabelWithCalloutHost.ts
+++ b/src/propertyFields/labelWithCallout/IPropertyFieldLabelWithCalloutHost.ts
@@ -1,5 +1,5 @@
 import { IPlaceholderWithCalloutProps } from '../../common/placeholderWithCallout/IPlaceholderWithCallout';
-import { ILabelProps } from '@fluentui/react/lib/components/Label';
+import { ILabelProps } from '@fluentui/react/lib/Label';
 
 /**
  * PropertyFieldLabelWithCalloutHost properties interface

--- a/src/propertyFields/labelWithCallout/PropertyFieldLabelWithCalloutHost.tsx
+++ b/src/propertyFields/labelWithCallout/PropertyFieldLabelWithCalloutHost.tsx
@@ -4,7 +4,7 @@ import PlaceholderWithCallout from '../../common/placeholderWithCallout/Placehol
 
 import { IPropertyFieldLabelWithCalloutHostProps } from './IPropertyFieldLabelWithCalloutHost';
 import * as telemetry from '../../common/telemetry';
-import { Label } from '@fluentui/react/lib/components/Label';
+import { Label } from '@fluentui/react/lib/Label';
 
 /**
 * Renders the control for PropertyFieldLabelWithCallout component

--- a/src/propertyFields/linkWithCallout/IPropertyFieldLinkWithCalloutHost.ts
+++ b/src/propertyFields/linkWithCallout/IPropertyFieldLinkWithCalloutHost.ts
@@ -1,6 +1,6 @@
 import { IPlaceholderWithCalloutProps } from '../../common/placeholderWithCallout/IPlaceholderWithCallout';
 import { IPopupWindowProps } from '@microsoft/sp-property-pane';
-import { ILinkProps } from '@fluentui/react/lib/components/Link';
+import { ILinkProps } from '@fluentui/react/lib/Link';
 
 /**
  * PropertyFieldLinkWithCalloutHost properties interface

--- a/src/propertyFields/linkWithCallout/PropertyFieldLinkWithCalloutHost.tsx
+++ b/src/propertyFields/linkWithCallout/PropertyFieldLinkWithCalloutHost.tsx
@@ -5,7 +5,7 @@ import type { IPlaceholderWithCalloutProps } from '../../common/placeholderWithC
 
 import { IPropertyFieldLinkWithCalloutHostProps } from './IPropertyFieldLinkWithCalloutHost';
 import * as telemetry from '../../common/telemetry';
-import { Link } from '@fluentui/react/lib/components/Link';
+import { Link } from '@fluentui/react/lib/Link';
 
 /**
 * Renders the control for PropertyFieldLinkWithCallout component

--- a/src/propertyFields/monacoEditor/monacoEditorControl/Error.tsx
+++ b/src/propertyFields/monacoEditor/monacoEditorControl/Error.tsx
@@ -1,5 +1,5 @@
 
-import { Stack } from "@fluentui/react/lib/components/Stack";
+import { Stack } from "@fluentui/react/lib/Stack";
 import { MessageBarType , MessageBar} from "@fluentui/react/lib/MessageBar";
 import * as React from "react";
 

--- a/src/propertyFields/multiSelect/IPropertyFieldMultiSelectHost.ts
+++ b/src/propertyFields/multiSelect/IPropertyFieldMultiSelectHost.ts
@@ -1,4 +1,4 @@
-import { IDropdownProps } from '@fluentui/react/lib/components/Dropdown';
+import { IDropdownProps } from '@fluentui/react/lib/Dropdown';
 
 /**
 * PropertyFieldMultiSelectHost properties interface

--- a/src/propertyFields/multiSelect/PropertyFieldMultiSelect.ts
+++ b/src/propertyFields/multiSelect/PropertyFieldMultiSelect.ts
@@ -1,4 +1,4 @@
-import { IDropdownOption } from '@fluentui/react/lib/components/Dropdown';
+import { IDropdownOption } from '@fluentui/react/lib/Dropdown';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import {

--- a/src/propertyFields/multiSelect/PropertyFieldMultiSelectHost.tsx
+++ b/src/propertyFields/multiSelect/PropertyFieldMultiSelectHost.tsx
@@ -1,6 +1,6 @@
 import * as strings from 'PropertyControlStrings';
 import * as React from 'react';
-import { Dropdown } from '@fluentui/react/lib/components/Dropdown';
+import { Dropdown } from '@fluentui/react/lib/Dropdown';
 import { IPropertyFieldMultiSelectHostProps } from './IPropertyFieldMultiSelectHost';
 import * as telemetry from '../../common/telemetry';
 

--- a/src/propertyFields/peoplePicker/IPropertyFieldPeoplePickerHost.ts
+++ b/src/propertyFields/peoplePicker/IPropertyFieldPeoplePickerHost.ts
@@ -1,5 +1,5 @@
 import { IPropertyFieldGroupOrPerson, IPropertyFieldPeoplePickerPropsInternal } from './IPropertyFieldPeoplePicker';
-import { IPersonaProps } from '@fluentui/react/lib/components/Persona';
+import { IPersonaProps } from '@fluentui/react/lib/Persona';
 
 /**
  * PropertyFieldPeoplePickerHost properties interface

--- a/src/propertyFields/search/IPropertyFieldSearch.ts
+++ b/src/propertyFields/search/IPropertyFieldSearch.ts
@@ -1,7 +1,7 @@
 import {
   IPropertyPaneCustomFieldProps,
 } from '@microsoft/sp-property-pane';
-import { ISearchBoxStyles } from '@fluentui/react/lib/components/SearchBox';
+import { ISearchBoxStyles } from '@fluentui/react/lib/SearchBox';
 
 export interface IPropertyFieldSearchProps {
   key: string;

--- a/src/propertyFields/search/IPropertyFieldSearchHost.ts
+++ b/src/propertyFields/search/IPropertyFieldSearchHost.ts
@@ -1,4 +1,4 @@
-import { ISearchBoxStyles } from "@fluentui/react/lib/components/SearchBox";
+import { ISearchBoxStyles } from "@fluentui/react/lib/SearchBox";
 
 export interface IPropertyFieldSearchHostProps {
   key: string;

--- a/src/propertyFields/sliderWithCallout/IPropertyFieldSliderWithCalloutHost.ts
+++ b/src/propertyFields/sliderWithCallout/IPropertyFieldSliderWithCalloutHost.ts
@@ -1,5 +1,5 @@
 import { IPropertyFieldHeaderCalloutProps } from '../../common/propertyFieldHeader/IPropertyFieldHeader';
-import { ISliderProps } from '@fluentui/react/lib/components/Slider';
+import { ISliderProps } from '@fluentui/react/lib/Slider';
 
 /**
  * PropertyFieldSliderWithCalloutHost properties interface

--- a/src/propertyFields/sliderWithCallout/PropertyFieldSliderWithCalloutHost.tsx
+++ b/src/propertyFields/sliderWithCallout/PropertyFieldSliderWithCalloutHost.tsx
@@ -4,7 +4,7 @@ import PropertyFieldHeader from '../../common/propertyFieldHeader/PropertyFieldH
 
 import { IPropertyFieldSliderWithCalloutHostProps } from './IPropertyFieldSliderWithCalloutHost';
 import * as telemetry from '../../common/telemetry';
-import { Slider } from '@fluentui/react/lib/components/Slider';
+import { Slider } from '@fluentui/react/lib/Slider';
 
 import omit from 'lodash/omit';
 

--- a/src/propertyFields/spinner/IPropertyFieldSpinner.ts
+++ b/src/propertyFields/spinner/IPropertyFieldSpinner.ts
@@ -1,7 +1,7 @@
 import {
   IPropertyPaneCustomFieldProps,
 } from '@microsoft/sp-property-pane';
-import { SpinnerSize } from '@fluentui/react/lib/components/Spinner';
+import { SpinnerSize } from '@fluentui/react/lib/Spinner';
 
 
 

--- a/src/propertyFields/spinner/PropertyFieldSpinnerHost.tsx
+++ b/src/propertyFields/spinner/PropertyFieldSpinnerHost.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Spinner } from "@fluentui/react/lib/components/Spinner";
+import { Spinner } from "@fluentui/react/lib/Spinner";
 //import styles from './Component.module.scss';
 
 import {

--- a/src/propertyFields/textWithCallout/IPropertyFieldTextWithCalloutHost.ts
+++ b/src/propertyFields/textWithCallout/IPropertyFieldTextWithCalloutHost.ts
@@ -1,5 +1,5 @@
 import { IPropertyFieldHeaderCalloutProps } from '../../common/propertyFieldHeader/IPropertyFieldHeader';
-import { ITextFieldProps } from '@fluentui/react/lib/components/TextField';
+import { ITextFieldProps } from '@fluentui/react/lib/TextField';
 
 /**
  * PropertyFieldTextWithCalloutHost properties interface

--- a/src/propertyFields/textWithCallout/PropertyFieldTextWithCalloutHost.tsx
+++ b/src/propertyFields/textWithCallout/PropertyFieldTextWithCalloutHost.tsx
@@ -4,7 +4,7 @@ import PropertyFieldHeader from '../../common/propertyFieldHeader/PropertyFieldH
 
 import { IPropertyFieldTextWithCalloutHostProps } from './IPropertyFieldTextWithCalloutHost';
 import * as telemetry from '../../common/telemetry';
-import { TextField } from '@fluentui/react/lib/components/TextField';
+import { TextField } from '@fluentui/react/lib/TextField';
 import omit from 'lodash/omit';
 
 export default class PropertyFieldTextWithCalloutHost extends React.Component<IPropertyFieldTextWithCalloutHostProps, null> {

--- a/src/propertyFields/toggleWithCallout/IPropertyFieldToggleWithCalloutHost.ts
+++ b/src/propertyFields/toggleWithCallout/IPropertyFieldToggleWithCalloutHost.ts
@@ -1,5 +1,5 @@
 import { IPropertyFieldHeaderCalloutProps } from '../../common/propertyFieldHeader/IPropertyFieldHeader';
-import { IToggleProps } from '@fluentui/react/lib/components/Toggle';
+import { IToggleProps } from '@fluentui/react/lib/Toggle';
 
 /**
  * PropertyFieldToggleWithCalloutHost properties interface

--- a/src/propertyFields/toggleWithCallout/PropertyFieldToggleWithCalloutHost.tsx
+++ b/src/propertyFields/toggleWithCallout/PropertyFieldToggleWithCalloutHost.tsx
@@ -5,7 +5,7 @@ import type { IPropertyFieldHeaderProps } from '../../common/propertyFieldHeader
 
 import { IPropertyFieldToggleWithCalloutHostProps } from './IPropertyFieldToggleWithCalloutHost';
 import * as telemetry from '../../common/telemetry';
-import { Toggle } from '@fluentui/react/lib/components/Toggle';
+import { Toggle } from '@fluentui/react/lib/Toggle';
 
 import omit from 'lodash/omit';
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

The latest version of Fluent UI specifies a list of exported modules in its package.json. Only these exports can be safely imported. With SPFx 1.19 and Webpack 5, using other exports will crash while creating the bundle.

This PR updates the imports throughout the project to use the correct exports, which will allow the project to be used with the latest SPFx toolchain.