### PR TITLE
fix(dependencies): Update "markdown-to-jsx" to "^7.4.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@uifabric/icons": "7.5.17",
     "brace": "0.11.1",
     "lodash.omit": "4.5.0",
-    "markdown-to-jsx": "^6.11.4",
+    "markdown-to-jsx": "^7.4.0",
     "monaco-editor": "^0.32.1",
     "react": "17.0.1",
     "react-ace": "10.1.0",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #634

#### What's in this Pull Request?

Version bump of markdown-to-jsx from 6.x.x to version 7.4.0

