### PR TITLE
Async dispose in Component unmount

### DIFF
--- a/src/propertyFields/collectionData/collectionColorField/CollectionColorField.tsx
+++ b/src/propertyFields/collectionData/collectionColorField/CollectionColorField.tsx
@@ -35,6 +35,13 @@ export class CollectionColorField extends React.Component<ICollectionColorFieldP
   public UNSAFE_componentWillMount(): void {
     this.valueChange(this.props.field, this.props.item[this.props.field.id]).then(() => { /* no-op; */ }).catch(() => { /* no-op; */ });
   }
+  
+  /**
+   * componentWillUnmount lifecycle hook
+   */
+  public componentWillUnmount(): void {
+    this.async.dispose();
+  }
 
   private _onCalloutDismiss = (): void => {
     this.setState({

--- a/src/propertyFields/collectionData/collectionNumberField/CollectionNumberField.tsx
+++ b/src/propertyFields/collectionData/collectionNumberField/CollectionNumberField.tsx
@@ -68,6 +68,13 @@ export class CollectionNumberField extends React.Component<
   }
 
   /**
+   * componentWillUnmount lifecycle hook
+   */
+  public componentWillUnmount(): void {
+    this.async.dispose();
+  }
+
+  /**
    * Value change event handler
    *
    * @param field

--- a/src/propertyFields/number/PropertyFieldNumberHost.tsx
+++ b/src/propertyFields/number/PropertyFieldNumberHost.tsx
@@ -58,6 +58,13 @@ export default class PropertyFieldNumberHost extends React.Component<IPropertyFi
   }
 
   /**
+   * componentWillUnmount lifecycle hook
+   */
+  public componentWillUnmount(): void {
+    this._async.dispose();
+  }
+
+  /**
    * Validate if field value is a number
    * @param value
    */

--- a/src/propertyFields/sitePicker/PropertyFieldSitePickerHost.tsx
+++ b/src/propertyFields/sitePicker/PropertyFieldSitePickerHost.tsx
@@ -83,6 +83,13 @@ export default class PropertyFieldSitePickerHost extends React.Component<IProper
     this.setState({ selectedSites });
   }
 
+  /**
+   * componentWillUnmount lifecycle hook
+   */
+  public componentWillUnmount(): void {
+    this.async.dispose();
+  }
+
   public render(): JSX.Element {
     const { isLoading, siteSearchResults, selectedSites } = this.state;
 

--- a/src/propertyFields/teamPicker/PropertyFieldTeamPickerHost.tsx
+++ b/src/propertyFields/teamPicker/PropertyFieldTeamPickerHost.tsx
@@ -89,6 +89,13 @@ export default class PropertyFieldTeamPickerHost extends React.Component<IProper
     this.setState({ selectedTeams });
   }
 
+  /**
+   * componentWillUnmount lifecycle hook
+   */
+  public componentWillUnmount(): void {
+    this.async.dispose();
+  }
+
   public render(): JSX.Element {
     const { isLoading, teamSearchResults, selectedTeams } = this.state;
 


### PR DESCRIPTION
Dispose of `Async` instances in React Component will unmount lifecycle hooks. Avoids memory references preventing GC.

Reference: https://github.com/microsoft/fluentui/blob/bf60a56cb23b3af90bcb62462c2423468eb9fa3c/packages/utilities/src/Async.ts#L38